### PR TITLE
Fix ankle ROM, initial hip angles, plate inertia, and bench grip

### DIFF
--- a/src/drake_models/exercises/bench_press/bench_press_model.py
+++ b/src/drake_models/exercises/bench_press/bench_press_model.py
@@ -46,7 +46,7 @@ BENCH_PAD_MASS = 30.0
 # Grip offset from barbell center (meters) — approximately shoulder width.
 # Standard competition bench press grip is ~0.81 m between index fingers;
 # modelled here as offset from shaft center to each hand attachment point.
-GRIP_OFFSET = 0.20  # meters from barbell center to each hand
+GRIP_OFFSET = 0.40  # meters from barbell center to each hand
 
 # Supine pelvis orientation: pitched -90 degrees about Y so body lies flat.
 # Drake Z-up / X-forward convention: SDF pose format is "x y z roll pitch yaw".

--- a/src/drake_models/exercises/clean_and_jerk/clean_and_jerk_model.py
+++ b/src/drake_models/exercises/clean_and_jerk/clean_and_jerk_model.py
@@ -39,7 +39,7 @@ from drake_models.shared.body import BodyModelSpec
 logger = logging.getLogger(__name__)
 
 # Initial joint angles for the clean setup position (radians).
-CLEAN_INITIAL_HIP_ANGLE = math.pi * 50 / 180  # ~50 degrees hip flexion
+CLEAN_INITIAL_HIP_ANGLE = math.pi * 70 / 180  # ~70 degrees hip flexion
 CLEAN_INITIAL_KNEE_ANGLE = -math.pi / 3  # ~60 degrees knee flexion
 CLEAN_INITIAL_LUMBAR_ANGLE = math.pi * 10 / 180  # ~10 degrees lumbar flexion
 

--- a/src/drake_models/exercises/deadlift/deadlift_model.py
+++ b/src/drake_models/exercises/deadlift/deadlift_model.py
@@ -33,7 +33,7 @@ logger = logging.getLogger(__name__)
 GRIP_OFFSET = 0.22
 
 # Initial joint angles for the setup position (radians).
-DEADLIFT_INITIAL_HIP_ANGLE = math.pi / 3  # ~60 degrees hip flexion
+DEADLIFT_INITIAL_HIP_ANGLE = 1.3963  # ~80 degrees hip flexion
 DEADLIFT_INITIAL_KNEE_ANGLE = -math.pi * 70 / 180  # ~70 degrees knee flexion
 DEADLIFT_INITIAL_LUMBAR_ANGLE = math.pi * 15 / 180  # ~15 degrees lumbar flexion
 

--- a/src/drake_models/exercises/snatch/snatch_model.py
+++ b/src/drake_models/exercises/snatch/snatch_model.py
@@ -35,7 +35,7 @@ from drake_models.shared.body import BodyModelSpec
 logger = logging.getLogger(__name__)
 
 # Initial joint angles for the first-pull setup position (radians).
-SNATCH_INITIAL_HIP_ANGLE = math.pi / 3  # ~60 degrees hip flexion
+SNATCH_INITIAL_HIP_ANGLE = 1.3963  # ~80 degrees hip flexion
 SNATCH_INITIAL_KNEE_ANGLE = -math.pi / 3  # ~60 degrees knee flexion
 SNATCH_INITIAL_SHOULDER_ANGLE = math.pi / 6  # ~30 degrees shoulder flexion
 

--- a/src/drake_models/shared/barbell/barbell_model.py
+++ b/src/drake_models/shared/barbell/barbell_model.py
@@ -37,7 +37,10 @@ from drake_models.shared.contracts.preconditions import (
     require_non_negative,
     require_positive,
 )
-from drake_models.shared.utils.geometry import cylinder_inertia
+from drake_models.shared.utils.geometry import (
+    cylinder_inertia,
+    hollow_cylinder_inertia,
+)
 from drake_models.shared.utils.sdf_helpers import (
     add_fixed_joint,
     add_link,
@@ -139,6 +142,19 @@ def _cylinder_inertia_y_axis(
     return (ixx_t, izz_axial, iyy_t)
 
 
+def _hollow_cylinder_inertia_y_axis(
+    mass: float, inner_radius: float, outer_radius: float, length: float
+) -> tuple[float, float, float]:
+    """Principal inertias (Ixx, Iyy, Izz) for a hollow cylinder aligned along Y.
+
+    Same axis swap as ``_cylinder_inertia_y_axis`` but for a hollow cylinder.
+    """
+    ixx_t, iyy_t, izz_axial = hollow_cylinder_inertia(
+        mass, inner_radius, outer_radius, length
+    )
+    return (ixx_t, izz_axial, iyy_t)
+
+
 def create_barbell_links(
     model: ET.Element,
     spec: BarbellSpec,
@@ -165,10 +181,27 @@ def create_barbell_links(
         spec.shaft_mass, spec.shaft_radius, spec.shaft_length
     )
 
-    sleeve_total_mass = spec.sleeve_mass + spec.plate_mass_per_side
+    # Compute bare sleeve inertia
     sleeve_inertia = _cylinder_inertia_y_axis(
-        sleeve_total_mass, spec.sleeve_radius, spec.sleeve_length
+        spec.sleeve_mass, spec.sleeve_radius, spec.sleeve_length
     )
+
+    # Add plate inertia using correct plate radius (0.225 m), not sleeve radius
+    if spec.plate_mass_per_side > 0:
+        plate_thickness = max(0.01, spec.plate_mass_per_side * 0.002)
+        plate_inertia = _hollow_cylinder_inertia_y_axis(
+            spec.plate_mass_per_side,
+            inner_radius=spec.sleeve_radius,
+            outer_radius=0.225,
+            length=plate_thickness,
+        )
+        sleeve_inertia = (
+            sleeve_inertia[0] + plate_inertia[0],
+            sleeve_inertia[1] + plate_inertia[1],
+            sleeve_inertia[2] + plate_inertia[2],
+        )
+
+    sleeve_total_mass = spec.sleeve_mass + spec.plate_mass_per_side
 
     shaft_name = f"{prefix}_shaft"
     left_name = f"{prefix}_left_sleeve"

--- a/src/drake_models/shared/body/body_model.py
+++ b/src/drake_models/shared/body/body_model.py
@@ -84,8 +84,9 @@ HIP_FLEXION_LIMIT: float = 2.0944  # +120 degrees
 # Knee range of motion (radians): flexion to neutral.
 KNEE_FLEXION_LIMIT: float = -2.618  # -150 degrees
 
-# Ankle range of motion (radians): +/-45 degrees.
-ANKLE_ROM: float = 0.7854
+# Ankle range of motion (radians): asymmetric plantarflexion / dorsiflexion.
+ANKLE_PLANTAR_MAX: float = -0.8727  # -50 degrees plantarflexion
+ANKLE_DORSI_MAX: float = 0.3491  # +20 degrees dorsiflexion
 
 
 @dataclass(frozen=True)
@@ -378,8 +379,8 @@ def create_full_body(
             parent_offset_z=-sh_len,
             parent_lateral_y=0,
             coord_prefix="ankle",
-            range_min=-ANKLE_ROM,
-            range_max=ANKLE_ROM,
+            range_min=ANKLE_PLANTAR_MAX,
+            range_max=ANKLE_DORSI_MAX,
         )
     )
 

--- a/src/drake_models/shared/utils/geometry.py
+++ b/src/drake_models/shared/utils/geometry.py
@@ -45,6 +45,39 @@ def cylinder_inertia(
     return (ixx, iyy, izz)
 
 
+def hollow_cylinder_inertia(
+    mass: float,
+    inner_radius: float,
+    outer_radius: float,
+    length: float,
+) -> tuple[float, float, float]:
+    """Inertia tensor for a hollow cylinder with axis along Z.
+
+    Returns (ixx, iyy, izz) where izz is axial moment, ixx=iyy are transverse.
+
+    Args:
+        mass: Total mass in kg
+        inner_radius: Inner bore radius in metres
+        outer_radius: Outer radius in metres
+        length: Length in metres
+    """
+    require_positive(mass, "mass")
+    require_positive(inner_radius, "inner_radius")
+    require_positive(outer_radius, "outer_radius")
+    require_positive(length, "length")
+    if inner_radius >= outer_radius:
+        raise ValueError(
+            f"inner_radius ({inner_radius:.4f}) must be less than "
+            f"outer_radius ({outer_radius:.4f})"
+        )
+    r_sq_sum = inner_radius**2 + outer_radius**2
+    izz = 0.5 * mass * r_sq_sum  # axial
+    ixx = iyy = (1.0 / 12.0) * mass * (3.0 * r_sq_sum + length**2)  # transverse
+
+    ensure_positive_definite_inertia(ixx, iyy, izz, "hollow_cylinder")
+    return ixx, iyy, izz
+
+
 def rectangular_prism_inertia(
     mass: float, width: float, height: float, depth: float
 ) -> tuple[float, float, float]:


### PR DESCRIPTION
## Summary
- **Ankle ROM** (#49): Replace symmetric +/-45 deg with asymmetric plantarflexion -50 deg / dorsiflexion +20 deg using separate `ANKLE_PLANTAR_MAX` and `ANKLE_DORSI_MAX` constants
- **Deadlift hip angle** (#50): Increase initial hip flexion from 60 deg to 80 deg
- **Snatch/Clean hip angles** (#51): Snatch 60->80 deg, Clean 50->70 deg
- **Plate inertia** (#52): Add `hollow_cylinder_inertia()` and compute plate inertia using correct 0.225m plate radius instead of sleeve radius
- **Bench grip** (#53): Increase grip offset from 0.20m to 0.40m for realistic shoulder-width grip

Closes #49, closes #50, closes #51, closes #52, closes #53

## Test plan
- [x] All 313 unit/integration tests pass (1 skipped)
- [x] ruff check and format clean
- [x] Pre-existing Drake API test failure (`AddModelFromFile` renamed) is unrelated
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)