### PR TITLE
feat: multi-DOF compound joints for biomechanical accuracy

### DIFF
--- a/src/drake_models/exercises/bench_press/bench_press_model.py
+++ b/src/drake_models/exercises/bench_press/bench_press_model.py
@@ -168,13 +168,16 @@ class BenchPressModelBuilder(ExerciseModelBuilder):
         The lifter lies on the bench with arms extended vertically,
         holding the barbell at arm's length above the chest.
         Positive shoulder flexion = arms pointing toward ceiling when supine.
+        Shoulder adduction set for bench press grip width.
         """
         self._write_initial_pose(
             model,
             "lockout",
             {
-                "shoulder_l": BENCH_INITIAL_SHOULDER_ANGLE,
-                "shoulder_r": BENCH_INITIAL_SHOULDER_ANGLE,
+                "shoulder_l_flex": BENCH_INITIAL_SHOULDER_ANGLE,
+                "shoulder_r_flex": BENCH_INITIAL_SHOULDER_ANGLE,
+                "shoulder_l_adduct": 0.0,
+                "shoulder_r_adduct": 0.0,
                 "elbow_l": BENCH_INITIAL_ELBOW_ANGLE,
                 "elbow_r": BENCH_INITIAL_ELBOW_ANGLE,
             },

--- a/src/drake_models/exercises/clean_and_jerk/clean_and_jerk_model.py
+++ b/src/drake_models/exercises/clean_and_jerk/clean_and_jerk_model.py
@@ -87,11 +87,11 @@ class CleanAndJerkModelBuilder(ExerciseModelBuilder):
             model,
             "clean_setup",
             {
-                "hip_l": CLEAN_INITIAL_HIP_ANGLE,
-                "hip_r": CLEAN_INITIAL_HIP_ANGLE,
+                "hip_l_flex": CLEAN_INITIAL_HIP_ANGLE,
+                "hip_r_flex": CLEAN_INITIAL_HIP_ANGLE,
                 "knee_l": CLEAN_INITIAL_KNEE_ANGLE,
                 "knee_r": CLEAN_INITIAL_KNEE_ANGLE,
-                "lumbar": CLEAN_INITIAL_LUMBAR_ANGLE,
+                "lumbar_flex": CLEAN_INITIAL_LUMBAR_ANGLE,
             },
         )
 

--- a/src/drake_models/exercises/deadlift/deadlift_model.py
+++ b/src/drake_models/exercises/deadlift/deadlift_model.py
@@ -74,11 +74,11 @@ class DeadliftModelBuilder(ExerciseModelBuilder):
             model,
             "setup",
             {
-                "hip_l": DEADLIFT_INITIAL_HIP_ANGLE,
-                "hip_r": DEADLIFT_INITIAL_HIP_ANGLE,
+                "hip_l_flex": DEADLIFT_INITIAL_HIP_ANGLE,
+                "hip_r_flex": DEADLIFT_INITIAL_HIP_ANGLE,
                 "knee_l": DEADLIFT_INITIAL_KNEE_ANGLE,
                 "knee_r": DEADLIFT_INITIAL_KNEE_ANGLE,
-                "lumbar": DEADLIFT_INITIAL_LUMBAR_ANGLE,
+                "lumbar_flex": DEADLIFT_INITIAL_LUMBAR_ANGLE,
             },
         )
 

--- a/src/drake_models/exercises/snatch/snatch_model.py
+++ b/src/drake_models/exercises/snatch/snatch_model.py
@@ -76,17 +76,20 @@ class SnatchModelBuilder(ExerciseModelBuilder):
 
         The lifter is in the first-pull position with significant hip and
         knee flexion and arms reaching down to the wide-grip bar.
+        Shoulder abduction for the overhead catch position.
         """
         self._write_initial_pose(
             model,
             "first_pull",
             {
-                "hip_l": SNATCH_INITIAL_HIP_ANGLE,
-                "hip_r": SNATCH_INITIAL_HIP_ANGLE,
+                "hip_l_flex": SNATCH_INITIAL_HIP_ANGLE,
+                "hip_r_flex": SNATCH_INITIAL_HIP_ANGLE,
                 "knee_l": SNATCH_INITIAL_KNEE_ANGLE,
                 "knee_r": SNATCH_INITIAL_KNEE_ANGLE,
-                "shoulder_l": SNATCH_INITIAL_SHOULDER_ANGLE,
-                "shoulder_r": SNATCH_INITIAL_SHOULDER_ANGLE,
+                "shoulder_l_flex": SNATCH_INITIAL_SHOULDER_ANGLE,
+                "shoulder_r_flex": SNATCH_INITIAL_SHOULDER_ANGLE,
+                "shoulder_l_adduct": 0.5236,  # ~30 deg abduction for wide grip
+                "shoulder_r_adduct": 0.5236,
             },
         )
 

--- a/src/drake_models/exercises/squat/squat_model.py
+++ b/src/drake_models/exercises/squat/squat_model.py
@@ -86,14 +86,17 @@ class SquatModelBuilder(ExerciseModelBuilder):
         """Set standing unrack position: slight hip/knee flexion.
 
         Hip flexion ~5 degrees, knee flexion ~5 degrees for a natural
-        standing position after unracking the bar.
+        standing position after unracking the bar.  Hip external rotation
+        ~10 degrees for natural stance width.
         """
         self._write_initial_pose(
             model,
             "unrack",
             {
-                "hip_l": SQUAT_INITIAL_HIP_ANGLE,
-                "hip_r": SQUAT_INITIAL_HIP_ANGLE,
+                "hip_l_flex": SQUAT_INITIAL_HIP_ANGLE,
+                "hip_r_flex": SQUAT_INITIAL_HIP_ANGLE,
+                "hip_l_rotate": 0.17,  # ~10 degrees external rotation
+                "hip_r_rotate": 0.17,
                 "knee_l": SQUAT_INITIAL_KNEE_ANGLE,
                 "knee_r": SQUAT_INITIAL_KNEE_ANGLE,
             },

--- a/src/drake_models/shared/body/body_model.py
+++ b/src/drake_models/shared/body/body_model.py
@@ -5,16 +5,23 @@ Segments (bilateral where noted):
   upper_arm_{l,r}, forearm_{l,r}, hand_{l,r},
   thigh_{l,r}, shank_{l,r}, foot_{l,r}
 
-Joints:
+Virtual links (zero-mass, for compound joint chains):
+  hip_{l,r}_virtual_1, hip_{l,r}_virtual_2,
+  shoulder_{l,r}_virtual_1, shoulder_{l,r}_virtual_2,
+  lumbar_virtual_1, lumbar_virtual_2,
+  ankle_{l,r}_virtual_1,
+  wrist_{l,r}_virtual_1
+
+Joints (multi-DOF via compound revolute chains):
   ground_pelvis (floating — 6 DOF),
-  lumbar (revolute — flexion/extension),
+  lumbar_flex, lumbar_lateral, lumbar_rotate (3-DOF),
   neck (revolute),
-  shoulder_{l,r} (revolute — simplified, flexion only for v0.1),
+  shoulder_{l,r}_flex, shoulder_{l,r}_adduct, shoulder_{l,r}_rotate (3-DOF),
   elbow_{l,r} (revolute),
-  wrist_{l,r} (revolute),
-  hip_{l,r} (revolute — flexion/extension),
+  wrist_{l,r}_flex, wrist_{l,r}_deviate (2-DOF),
+  hip_{l,r}_flex, hip_{l,r}_adduct, hip_{l,r}_rotate (3-DOF),
   knee_{l,r} (revolute),
-  ankle_{l,r} (revolute)
+  ankle_{l,r}_flex, ankle_{l,r}_invert (2-DOF)
 
 Drake convention: Z-up, X-forward. Gravity = (0, 0, -9.80665).
 
@@ -42,6 +49,7 @@ from drake_models.shared.utils.sdf_helpers import (
     add_floating_joint,
     add_link,
     add_revolute_joint,
+    add_virtual_link,
     make_box_geometry,
     make_cylinder_geometry,
 )
@@ -61,31 +69,50 @@ SHOULDER_LATERAL_MULTIPLIER: float = 1.2
 # Lateral hip offset as a multiplier of pelvis radius.
 HIP_LATERAL_MULTIPLIER: float = 0.6
 
-# Lumbar joint range of motion (radians): extension, flexion.
-LUMBAR_EXTENSION_LIMIT: float = -0.5236  # -30 degrees
-LUMBAR_FLEXION_LIMIT: float = 0.7854  # +45 degrees
+# Lumbar joint range of motion (radians) — 3-DOF compound.
+LUMBAR_FLEX_LOWER: float = -0.5236  # -30 degrees extension
+LUMBAR_FLEX_UPPER: float = 0.7854  # +45 degrees flexion
+LUMBAR_LATERAL_LOWER: float = -0.5236  # -30 degrees
+LUMBAR_LATERAL_UPPER: float = 0.5236  # +30 degrees
+LUMBAR_ROTATE_LOWER: float = -0.5236  # -30 degrees
+LUMBAR_ROTATE_UPPER: float = 0.5236  # +30 degrees
 
 # Neck joint range of motion (radians).
 NECK_RANGE_LIMIT: float = 0.5236  # +/-30 degrees
 
-# Shoulder range of motion (radians): full circle for flexion/extension.
-SHOULDER_ROM: float = 3.1416  # +/-180 degrees
+# Shoulder range of motion (radians) — 3-DOF compound.
+SHOULDER_FLEX_LOWER: float = -1.0472  # -60 degrees
+SHOULDER_FLEX_UPPER: float = 3.1416  # +180 degrees
+SHOULDER_ADDUCT_LOWER: float = -0.5236  # -30 degrees
+SHOULDER_ADDUCT_UPPER: float = 3.1416  # +180 degrees
+SHOULDER_ROTATE_LOWER: float = -1.5708  # -90 degrees
+SHOULDER_ROTATE_UPPER: float = 1.5708  # +90 degrees
 
 # Elbow range of motion (radians): 0 to 150 degrees.
 ELBOW_FLEXION_LIMIT: float = 2.618
 
-# Wrist range of motion (radians): +/-70 degrees.
-WRIST_ROM: float = 1.2217
+# Wrist range of motion (radians) — 2-DOF compound.
+WRIST_FLEX_LOWER: float = -1.2217  # -70 degrees
+WRIST_FLEX_UPPER: float = 1.2217  # +70 degrees
+WRIST_DEVIATE_LOWER: float = -0.3491  # -20 degrees
+WRIST_DEVIATE_UPPER: float = 0.5236  # +30 degrees
 
-# Hip range of motion (radians): extension to flexion.
-HIP_EXTENSION_LIMIT: float = -0.5236  # -30 degrees
-HIP_FLEXION_LIMIT: float = 2.0944  # +120 degrees
+# Hip range of motion (radians) — 3-DOF compound.
+HIP_FLEX_LOWER: float = -0.5236  # -30 degrees extension
+HIP_FLEX_UPPER: float = 2.0944  # +120 degrees flexion
+HIP_ADDUCT_LOWER: float = -0.7854  # -45 degrees
+HIP_ADDUCT_UPPER: float = 0.5236  # +30 degrees
+HIP_ROTATE_LOWER: float = -0.7854  # -45 degrees
+HIP_ROTATE_UPPER: float = 0.7854  # +45 degrees
 
 # Knee range of motion (radians): flexion to neutral.
 KNEE_FLEXION_LIMIT: float = -2.618  # -150 degrees
 
-# Ankle range of motion (radians): +/-45 degrees.
-ANKLE_ROM: float = 0.7854
+# Ankle range of motion (radians) — 2-DOF compound.
+ANKLE_FLEX_LOWER: float = -0.3491  # -20 degrees
+ANKLE_FLEX_UPPER: float = 0.8727  # +50 degrees
+ANKLE_INVERT_LOWER: float = -0.3491  # -20 degrees
+ANKLE_INVERT_UPPER: float = 0.3491  # +20 degrees
 
 
 @dataclass(frozen=True)
@@ -179,6 +206,160 @@ def _add_bilateral_limb(
     return created
 
 
+def _add_compound_3dof_bilateral(
+    model: ET.Element,
+    spec: BodyModelSpec,
+    *,
+    seg_name: str,
+    parent_name: str,
+    parent_offset_z: float,
+    parent_lateral_y: float,
+    coord_prefix: str,
+    flex_limits: tuple[float, float],
+    adduct_limits: tuple[float, float],
+    rotate_limits: tuple[float, float],
+    adduct_label: str = "adduct",
+    rotate_label: str = "rotate",
+) -> dict[str, ET.Element]:
+    """Add bilateral 3-DOF compound joints via virtual links.
+
+    Chain per side:
+      parent -> {prefix}_flex joint -> virtual_1 -> {prefix}_adduct joint
+      -> virtual_2 -> {prefix}_rotate joint -> child segment link
+    """
+    mass, length, radius = _seg(spec, seg_name)
+    inertia = cylinder_inertia(mass, radius, length)
+    created: dict[str, ET.Element] = {}
+
+    for side, sign in [("l", -1.0), ("r", 1.0)]:
+        link_name = f"{seg_name}_{side}"
+        parent_link = f"{parent_name}_{side}" if "_" in parent_name else parent_name
+        v1_name = f"{coord_prefix}_{side}_virtual_1"
+        v2_name = f"{coord_prefix}_{side}_virtual_2"
+
+        # Virtual links
+        created[v1_name] = add_virtual_link(model, name=v1_name)
+        created[v2_name] = add_virtual_link(model, name=v2_name)
+
+        # Real segment link
+        created[link_name] = add_link(
+            model,
+            name=link_name,
+            mass=mass,
+            mass_center=(0, 0, -length / 2.0),
+            inertia_xx=inertia[0],
+            inertia_yy=inertia[1],
+            inertia_zz=inertia[2],
+            visual_geometry=make_cylinder_geometry(radius, length),
+            collision_geometry=make_cylinder_geometry(radius, length),
+        )
+
+        # Joint 1: flexion (X-axis) — parent to virtual_1
+        add_revolute_joint(
+            model,
+            name=f"{coord_prefix}_{side}_flex",
+            parent=parent_link,
+            child=v1_name,
+            axis_xyz=(1, 0, 0),
+            pose=(0, sign * parent_lateral_y, parent_offset_z, 0, 0, 0),
+            lower_limit=flex_limits[0],
+            upper_limit=flex_limits[1],
+        )
+        # Joint 2: adduction (Z-axis) — virtual_1 to virtual_2
+        add_revolute_joint(
+            model,
+            name=f"{coord_prefix}_{side}_{adduct_label}",
+            parent=v1_name,
+            child=v2_name,
+            axis_xyz=(0, 0, 1),
+            pose=(0, 0, 0, 0, 0, 0),
+            lower_limit=adduct_limits[0],
+            upper_limit=adduct_limits[1],
+        )
+        # Joint 3: rotation (Y-axis) — virtual_2 to child
+        add_revolute_joint(
+            model,
+            name=f"{coord_prefix}_{side}_{rotate_label}",
+            parent=v2_name,
+            child=link_name,
+            axis_xyz=(0, 1, 0),
+            pose=(0, 0, 0, 0, 0, 0),
+            lower_limit=rotate_limits[0],
+            upper_limit=rotate_limits[1],
+        )
+
+    return created
+
+
+def _add_compound_2dof_bilateral(
+    model: ET.Element,
+    spec: BodyModelSpec,
+    *,
+    seg_name: str,
+    parent_name: str,
+    parent_offset_z: float,
+    parent_lateral_y: float,
+    coord_prefix: str,
+    flex_limits: tuple[float, float],
+    second_limits: tuple[float, float],
+    second_label: str,
+) -> dict[str, ET.Element]:
+    """Add bilateral 2-DOF compound joints via one virtual link per side.
+
+    Chain per side:
+      parent -> {prefix}_flex joint -> virtual_1 -> {prefix}_{second} joint -> child
+    """
+    mass, length, radius = _seg(spec, seg_name)
+    inertia = cylinder_inertia(mass, radius, length)
+    created: dict[str, ET.Element] = {}
+
+    for side, sign in [("l", -1.0), ("r", 1.0)]:
+        link_name = f"{seg_name}_{side}"
+        parent_link = f"{parent_name}_{side}" if "_" in parent_name else parent_name
+        v1_name = f"{coord_prefix}_{side}_virtual_1"
+
+        # Virtual link
+        created[v1_name] = add_virtual_link(model, name=v1_name)
+
+        # Real segment link
+        created[link_name] = add_link(
+            model,
+            name=link_name,
+            mass=mass,
+            mass_center=(0, 0, -length / 2.0),
+            inertia_xx=inertia[0],
+            inertia_yy=inertia[1],
+            inertia_zz=inertia[2],
+            visual_geometry=make_cylinder_geometry(radius, length),
+            collision_geometry=make_cylinder_geometry(radius, length),
+        )
+
+        # Joint 1: flexion (X-axis) — parent to virtual_1
+        add_revolute_joint(
+            model,
+            name=f"{coord_prefix}_{side}_flex",
+            parent=parent_link,
+            child=v1_name,
+            axis_xyz=(1, 0, 0),
+            pose=(0, sign * parent_lateral_y, parent_offset_z, 0, 0, 0),
+            lower_limit=flex_limits[0],
+            upper_limit=flex_limits[1],
+        )
+        # Joint 2: second DOF (Z-axis) — virtual_1 to child
+        add_revolute_joint(
+            model,
+            name=f"{coord_prefix}_{side}_{second_label}",
+            parent=v1_name,
+            child=link_name,
+            axis_xyz=(0, 0, 1),
+            pose=(0, 0, 0, 0, 0, 0),
+            lower_limit=second_limits[0],
+            upper_limit=second_limits[1],
+        )
+
+    return created
+
+
 def create_full_body(
     model: ET.Element,
     spec: BodyModelSpec | None = None,
@@ -238,9 +419,13 @@ def create_full_body(
             pose=(0, 0, PELVIS_STANDING_HEIGHT, 0, 0, 0),
         )
 
-    # --- Torso ---
+    # --- Lumbar (3-DOF compound): pelvis -> v1 -> v2 -> torso ---
     t_mass, t_len, t_rad = _seg(spec, "torso")
     t_inertia = rectangular_prism_inertia(t_mass, t_rad * 2, t_len, t_rad * 2)
+
+    links["lumbar_virtual_1"] = add_virtual_link(model, name="lumbar_virtual_1")
+    links["lumbar_virtual_2"] = add_virtual_link(model, name="lumbar_virtual_2")
+
     links["torso"] = add_link(
         model,
         name="torso",
@@ -254,13 +439,33 @@ def create_full_body(
     )
     add_revolute_joint(
         model,
-        name="lumbar",
+        name="lumbar_flex",
         parent="pelvis",
-        child="torso",
+        child="lumbar_virtual_1",
         axis_xyz=(1, 0, 0),
         pose=(0, 0, p_len / 2.0, 0, 0, 0),
-        lower_limit=LUMBAR_EXTENSION_LIMIT,
-        upper_limit=LUMBAR_FLEXION_LIMIT,
+        lower_limit=LUMBAR_FLEX_LOWER,
+        upper_limit=LUMBAR_FLEX_UPPER,
+    )
+    add_revolute_joint(
+        model,
+        name="lumbar_lateral",
+        parent="lumbar_virtual_1",
+        child="lumbar_virtual_2",
+        axis_xyz=(0, 0, 1),
+        pose=(0, 0, 0, 0, 0, 0),
+        lower_limit=LUMBAR_LATERAL_LOWER,
+        upper_limit=LUMBAR_LATERAL_UPPER,
+    )
+    add_revolute_joint(
+        model,
+        name="lumbar_rotate",
+        parent="lumbar_virtual_2",
+        child="torso",
+        axis_xyz=(0, 1, 0),
+        pose=(0, 0, 0, 0, 0, 0),
+        lower_limit=LUMBAR_ROTATE_LOWER,
+        upper_limit=LUMBAR_ROTATE_UPPER,
     )
 
     # --- Head ---
@@ -288,12 +493,12 @@ def create_full_body(
         upper_limit=NECK_RANGE_LIMIT,
     )
 
-    # --- Arms ---
+    # --- Arms: Shoulder (3-DOF compound) ---
     shoulder_z = t_len * SHOULDER_HEIGHT_FRACTION
     shoulder_y = t_rad * SHOULDER_LATERAL_MULTIPLIER
 
     links.update(
-        _add_bilateral_limb(
+        _add_compound_3dof_bilateral(
             model,
             spec,
             seg_name="upper_arm",
@@ -301,11 +506,13 @@ def create_full_body(
             parent_offset_z=shoulder_z,
             parent_lateral_y=shoulder_y,
             coord_prefix="shoulder",
-            range_min=-SHOULDER_ROM,
-            range_max=SHOULDER_ROM,
+            flex_limits=(SHOULDER_FLEX_LOWER, SHOULDER_FLEX_UPPER),
+            adduct_limits=(SHOULDER_ADDUCT_LOWER, SHOULDER_ADDUCT_UPPER),
+            rotate_limits=(SHOULDER_ROTATE_LOWER, SHOULDER_ROTATE_UPPER),
         )
     )
 
+    # --- Arms: Elbow (1-DOF, unchanged) ---
     _ua_mass, ua_len, _ua_rad = _seg(spec, "upper_arm")
     links.update(
         _add_bilateral_limb(
@@ -321,9 +528,10 @@ def create_full_body(
         )
     )
 
+    # --- Arms: Wrist (2-DOF compound) ---
     _fa_mass, fa_len, _fa_rad = _seg(spec, "forearm")
     links.update(
-        _add_bilateral_limb(
+        _add_compound_2dof_bilateral(
             model,
             spec,
             seg_name="hand",
@@ -331,16 +539,17 @@ def create_full_body(
             parent_offset_z=-fa_len,
             parent_lateral_y=0,
             coord_prefix="wrist",
-            range_min=-WRIST_ROM,
-            range_max=WRIST_ROM,
+            flex_limits=(WRIST_FLEX_LOWER, WRIST_FLEX_UPPER),
+            second_limits=(WRIST_DEVIATE_LOWER, WRIST_DEVIATE_UPPER),
+            second_label="deviate",
         )
     )
 
-    # --- Legs ---
+    # --- Legs: Hip (3-DOF compound) ---
     hip_y = p_rad * HIP_LATERAL_MULTIPLIER
 
     links.update(
-        _add_bilateral_limb(
+        _add_compound_3dof_bilateral(
             model,
             spec,
             seg_name="thigh",
@@ -348,11 +557,13 @@ def create_full_body(
             parent_offset_z=-p_len / 2.0,
             parent_lateral_y=hip_y,
             coord_prefix="hip",
-            range_min=HIP_EXTENSION_LIMIT,
-            range_max=HIP_FLEXION_LIMIT,
+            flex_limits=(HIP_FLEX_LOWER, HIP_FLEX_UPPER),
+            adduct_limits=(HIP_ADDUCT_LOWER, HIP_ADDUCT_UPPER),
+            rotate_limits=(HIP_ROTATE_LOWER, HIP_ROTATE_UPPER),
         )
     )
 
+    # --- Legs: Knee (1-DOF, unchanged) ---
     _th_mass, th_len, _th_rad = _seg(spec, "thigh")
     links.update(
         _add_bilateral_limb(
@@ -368,9 +579,10 @@ def create_full_body(
         )
     )
 
+    # --- Legs: Ankle (2-DOF compound) ---
     _sh_mass, sh_len, _sh_rad = _seg(spec, "shank")
     links.update(
-        _add_bilateral_limb(
+        _add_compound_2dof_bilateral(
             model,
             spec,
             seg_name="foot",
@@ -378,8 +590,9 @@ def create_full_body(
             parent_offset_z=-sh_len,
             parent_lateral_y=0,
             coord_prefix="ankle",
-            range_min=-ANKLE_ROM,
-            range_max=ANKLE_ROM,
+            flex_limits=(ANKLE_FLEX_LOWER, ANKLE_FLEX_UPPER),
+            second_limits=(ANKLE_INVERT_LOWER, ANKLE_INVERT_UPPER),
+            second_label="invert",
         )
     )
 

--- a/src/drake_models/shared/utils/sdf_helpers.py
+++ b/src/drake_models/shared/utils/sdf_helpers.py
@@ -121,6 +121,29 @@ def make_sphere_geometry(radius: float) -> ET.Element:
     return geometry
 
 
+def add_virtual_link(
+    model: ET.Element,
+    *,
+    name: str,
+) -> ET.Element:
+    """Append a zero-mass virtual link for compound joint chains.
+
+    SDF requires a tree topology: compound (multi-DOF) joints are built by
+    chaining revolute joints through intermediate "virtual" links that carry
+    negligible mass and inertia.  This helper creates such a link with
+    mass = 1e-6 kg and principal inertia moments of 1e-6 each.
+    """
+    return add_link(
+        model,
+        name=name,
+        mass=1e-6,
+        mass_center=(0, 0, 0),
+        inertia_xx=1e-6,
+        inertia_yy=1e-6,
+        inertia_zz=1e-6,
+    )
+
+
 def add_revolute_joint(
     model: ET.Element,
     *,

--- a/tests/integration/test_all_exercises_build.py
+++ b/tests/integration/test_all_exercises_build.py
@@ -103,11 +103,11 @@ class TestAllExercisesBuild:
         ids=[n for n, _ in ALL_BUILDERS],  # type: ignore
     )
     def test_minimum_link_count(self, name: Any, builder: Any) -> None:
-        """Every exercise should have at least 18 links (15 body + 3 barbell)."""
+        """Every exercise should have at least 32 links (15 body + 14 virtual + 3 barbell)."""
         xml_str = builder()
         root = ET.fromstring(xml_str)
         links = root.findall(".//link")  # type: ignore
-        assert len(links) >= 18
+        assert len(links) >= 32
 
     @pytest.mark.parametrize(
         "name,builder",

--- a/tests/unit/exercises/test_exercise_edge_cases.py
+++ b/tests/unit/exercises/test_exercise_edge_cases.py
@@ -178,7 +178,7 @@ class TestEdgeCaseAnthropometrics:
             root = ET.fromstring(xml_str)
             assert root.tag == "sdf"
             links = root.findall(".//link")  # type: ignore
-            assert len(links) >= 18
+            assert len(links) >= 32
             for link in links:
                 mass_el = link.find("inertial/mass")  # type: ignore
                 assert mass_el is not None

--- a/tests/unit/shared/test_body_model.py
+++ b/tests/unit/shared/test_body_model.py
@@ -54,15 +54,19 @@ class TestCreateFullBody:
         assert "head" in links  # type: ignore
 
     def test_creates_minimum_links(self, model: Any) -> None:
-        """15 body segments: pelvis, torso, head + 6 bilateral pairs."""
+        """15 body + 18 virtual links = 33 minimum."""
         create_full_body(model)
         link_elements = model.findall("link")  # type: ignore
-        assert len(link_elements) >= 15
+        # 15 body + 2 lumbar virtual + 4 hip virtual + 4 shoulder virtual
+        # + 2 ankle virtual + 2 wrist virtual = 29
+        assert len(link_elements) >= 29
 
     def test_creates_joints(self, model: Any) -> None:
         create_full_body(model)
         joints = model.findall("joint")  # type: ignore
-        assert len(joints) >= 15
+        # 1 floating + 3 lumbar + 1 neck + 6 shoulder + 2 elbow + 4 wrist
+        # + 6 hip + 2 knee + 4 ankle = 29 joints
+        assert len(joints) >= 29
 
     def test_pelvis_has_floating_joint(self, model: Any) -> None:
         create_full_body(model)
@@ -105,17 +109,69 @@ class TestCreateFullBody:
         mass = float(pelvis.find("inertial/mass").text)  # type: ignore
         assert mass == pytest.approx(100.0 * 0.142)
 
-    def test_lumbar_joint(self, model: Any) -> None:
+    def test_lumbar_compound_joint(self, model: Any) -> None:
+        """Lumbar is now a 3-DOF compound: flex, lateral, rotate."""
         create_full_body(model)
-        lumbar = None
+        joint_names = {j.get("name") for j in model.findall("joint")}  # type: ignore
+        assert "lumbar_flex" in joint_names  # type: ignore
+        assert "lumbar_lateral" in joint_names  # type: ignore
+        assert "lumbar_rotate" in joint_names  # type: ignore
+
+        # Check chain: pelvis -> v1 -> v2 -> torso
         for j in model.findall("joint"):
-            if j.get("name") == "lumbar":  # type: ignore
-                lumbar = j
-                break
-        assert lumbar is not None
-        assert lumbar.get("type") == "revolute"  # type: ignore
-        assert lumbar.find("parent").text == "pelvis"  # type: ignore
-        assert lumbar.find("child").text == "torso"  # type: ignore
+            if j.get("name") == "lumbar_flex":  # type: ignore
+                assert j.find("parent").text == "pelvis"  # type: ignore
+                assert j.find("child").text == "lumbar_virtual_1"  # type: ignore
+            elif j.get("name") == "lumbar_rotate":  # type: ignore
+                assert j.find("child").text == "torso"  # type: ignore
+
+    def test_hip_compound_joints(self, model: Any) -> None:
+        """Hip is now a 3-DOF compound: flex, adduct, rotate (bilateral)."""
+        create_full_body(model)
+        joint_names = {j.get("name") for j in model.findall("joint")}  # type: ignore
+        for side in ("l", "r"):
+            assert f"hip_{side}_flex" in joint_names  # type: ignore
+            assert f"hip_{side}_adduct" in joint_names  # type: ignore
+            assert f"hip_{side}_rotate" in joint_names  # type: ignore
+
+    def test_shoulder_compound_joints(self, model: Any) -> None:
+        """Shoulder is now a 3-DOF compound: flex, adduct, rotate (bilateral)."""
+        create_full_body(model)
+        joint_names = {j.get("name") for j in model.findall("joint")}  # type: ignore
+        for side in ("l", "r"):
+            assert f"shoulder_{side}_flex" in joint_names  # type: ignore
+            assert f"shoulder_{side}_adduct" in joint_names  # type: ignore
+            assert f"shoulder_{side}_rotate" in joint_names  # type: ignore
+
+    def test_ankle_compound_joints(self, model: Any) -> None:
+        """Ankle is now a 2-DOF compound: flex, invert (bilateral)."""
+        create_full_body(model)
+        joint_names = {j.get("name") for j in model.findall("joint")}  # type: ignore
+        for side in ("l", "r"):
+            assert f"ankle_{side}_flex" in joint_names  # type: ignore
+            assert f"ankle_{side}_invert" in joint_names  # type: ignore
+
+    def test_wrist_compound_joints(self, model: Any) -> None:
+        """Wrist is now a 2-DOF compound: flex, deviate (bilateral)."""
+        create_full_body(model)
+        joint_names = {j.get("name") for j in model.findall("joint")}  # type: ignore
+        for side in ("l", "r"):
+            assert f"wrist_{side}_flex" in joint_names  # type: ignore
+            assert f"wrist_{side}_deviate" in joint_names  # type: ignore
+
+    def test_virtual_links_present(self, model: Any) -> None:
+        """Virtual links must exist for compound joint chains."""
+        create_full_body(model)
+        link_names = {el.get("name") for el in model.findall("link")}  # type: ignore
+        assert "lumbar_virtual_1" in link_names  # type: ignore
+        assert "lumbar_virtual_2" in link_names  # type: ignore
+        for side in ("l", "r"):
+            assert f"hip_{side}_virtual_1" in link_names  # type: ignore
+            assert f"hip_{side}_virtual_2" in link_names  # type: ignore
+            assert f"shoulder_{side}_virtual_1" in link_names  # type: ignore
+            assert f"shoulder_{side}_virtual_2" in link_names  # type: ignore
+            assert f"ankle_{side}_virtual_1" in link_names  # type: ignore
+            assert f"wrist_{side}_virtual_1" in link_names  # type: ignore
 
     def test_neck_joint(self, model: Any) -> None:
         create_full_body(model)
@@ -128,36 +184,50 @@ class TestCreateFullBody:
         assert neck.find("parent").text == "torso"  # type: ignore
         assert neck.find("child").text == "head"  # type: ignore
 
-    def test_joint_axis_is_x(self, model: Any) -> None:
-        """All revolute joints use X-axis for sagittal-plane flexion."""
+    def test_joint_axes_are_valid(self, model: Any) -> None:
+        """Revolute joints use X (flex), Z (adduct/lateral), or Y (rotate) axes."""
+        valid_axes = {
+            "1.000000 0.000000 0.000000",
+            "0.000000 0.000000 1.000000",
+            "0.000000 1.000000 0.000000",
+        }
         create_full_body(model)
         for j in model.findall("joint"):
             if j.get("type") == "revolute":  # type: ignore
-                xyz = j.find("axis/xyz").text  # type: ignore
-                assert "1.000000 0.000000 0.000000" in xyz  # type: ignore
+                xyz = j.find("axis/xyz").text.strip()  # type: ignore
+                assert xyz in valid_axes, (  # type: ignore
+                    f"Joint {j.get('name')} has unexpected axis: {xyz}"
+                )
 
     def test_links_have_visual_geometry(self, model: Any) -> None:
         create_full_body(model)
         for link in model.findall("link"):
-            assert link.find("visual") is not None, f"{link.get('name')} missing visual"  # type: ignore
+            name = link.get("name")  # type: ignore
+            if "virtual" in name:  # type: ignore
+                continue  # virtual links have no geometry
+            assert link.find("visual") is not None, f"{name} missing visual"  # type: ignore
 
     def test_links_have_collision_geometry(self, model: Any) -> None:
         create_full_body(model)
         for link in model.findall("link"):
+            name = link.get("name")  # type: ignore
+            if "virtual" in name:  # type: ignore
+                continue  # virtual links have no geometry
             assert link.find("collision") is not None, (  # type: ignore
-                f"{link.get('name')} missing collision"
+                f"{name} missing collision"
             )
 
     def test_total_mass_approximately_correct(self, model: Any) -> None:
-        """Total mass of all links must exactly equal spec.total_mass.
+        """Total mass of body links must equal spec.total_mass.
 
-        Segment fractions from the Winter (2009) table sum to 1.0 by design;
-        the 5 % tolerance previously used masked rounding drift.  Use rel=1e-9
-        to catch any future regression in the segment table or mass allocation.
+        Segment fractions from the Winter (2009) table sum to 1.0 by design.
+        Virtual links add negligible mass (1e-6 kg each), so we use abs
+        tolerance to account for them while catching real regressions.
         """
         spec = BodyModelSpec(total_mass=80.0)
         create_full_body(model, spec)
         total = sum(
             float(el.find("inertial/mass").text) for el in model.findall("link")
         )
-        assert total == pytest.approx(80.0, rel=1e-9)
+        # 14 virtual links * 1e-6 kg = 14e-6 kg added
+        assert total == pytest.approx(80.0, abs=1e-3)

--- a/tests/unit/shared/test_sdf_helpers.py
+++ b/tests/unit/shared/test_sdf_helpers.py
@@ -10,6 +10,7 @@ from drake_models.shared.utils.sdf_helpers import (
     add_floating_joint,
     add_link,
     add_revolute_joint,
+    add_virtual_link,
     make_box_geometry,
     make_cylinder_geometry,
     make_sphere_geometry,
@@ -181,6 +182,34 @@ class TestAddLink:
         assert "0.100000" in pose.text  # type: ignore
         assert "0.200000" in pose.text  # type: ignore
         assert "0.300000" in pose.text  # type: ignore
+
+
+class TestAddVirtualLink:
+    @pytest.fixture()
+    def model(self) -> ET.Element:
+        return ET.Element("model", name="test")
+
+    def test_creates_link_with_name(self, model: Any) -> None:
+        link = add_virtual_link(model, name="hip_l_virtual_1")
+        assert link.tag == "link"
+        assert link.get("name") == "hip_l_virtual_1"  # type: ignore
+
+    def test_zero_mass(self, model: Any) -> None:
+        link = add_virtual_link(model, name="v1")
+        mass_el = link.find("inertial/mass")  # type: ignore
+        assert float(mass_el.text) == pytest.approx(1e-6)  # type: ignore
+
+    def test_minimal_inertia(self, model: Any) -> None:
+        link = add_virtual_link(model, name="v1")
+        inertia = link.find("inertial/inertia")  # type: ignore
+        assert float(inertia.find("ixx").text) == pytest.approx(1e-6)  # type: ignore
+        assert float(inertia.find("iyy").text) == pytest.approx(1e-6)  # type: ignore
+        assert float(inertia.find("izz").text) == pytest.approx(1e-6)  # type: ignore
+
+    def test_no_visual_or_collision(self, model: Any) -> None:
+        link = add_virtual_link(model, name="v1")
+        assert link.find("visual") is None  # type: ignore
+        assert link.find("collision") is None  # type: ignore
 
 
 class TestAddRevoluteJoint:


### PR DESCRIPTION
## Summary
- Replace single-DOF revolute joints with anatomically accurate multi-DOF compound joint chains using zero-mass virtual links (SDF tree topology constraint)
- Hip and shoulder joints upgraded to 3-DOF (flexion/adduction/rotation), lumbar to 3-DOF (flex/lateral/rotate), ankle to 2-DOF (flex/inversion), wrist to 2-DOF (flex/deviation)
- Adds `add_virtual_link()` helper to `sdf_helpers.py` for creating zero-mass intermediate links
- Updates all 5 exercise builders with renamed joint coordinates in initial pose blocks (e.g. `hip_l` -> `hip_l_flex`)
- All 369 tests pass with updated joint/link count assertions

## Changes
| File | Change |
|------|--------|
| `sdf_helpers.py` | New `add_virtual_link()` helper |
| `body_model.py` | 3-DOF hip, shoulder, lumbar; 2-DOF ankle, wrist via virtual link chains |
| `squat_model.py` | Updated joint names, added hip external rotation (~10 deg) |
| `bench_press_model.py` | Updated joint names, added shoulder adduction DOF |
| `snatch_model.py` | Updated joint names, added shoulder abduction for wide grip |
| `deadlift_model.py` | Updated joint names (`hip_l` -> `hip_l_flex`, `lumbar` -> `lumbar_flex`) |
| `clean_and_jerk_model.py` | Updated joint names |
| Tests | Updated link/joint count assertions, added compound joint and virtual link tests |

## Test plan
- [x] `python -m ruff check src/ tests/` -- zero violations
- [x] `python -m ruff format src/ tests/` -- zero changes
- [x] `python -m pytest tests/ -x --tb=short` -- 369 passed, 19 skipped
- [ ] Review SDF output XML for correct joint chain topology
- [ ] Verify Drake loading with `pydrake` (requires Drake environment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)