### PR TITLE
feat: add ground contact models with hydroelastic contact

### DIFF
--- a/src/drake_models/exercises/base.py
+++ b/src/drake_models/exercises/base.py
@@ -19,7 +19,12 @@ from dataclasses import dataclass, field
 from drake_models.shared.barbell import BarbellSpec, create_barbell_links
 from drake_models.shared.body import BodyModelSpec, create_full_body
 from drake_models.shared.contracts.postconditions import ensure_valid_xml
-from drake_models.shared.utils.sdf_helpers import serialize_model, vec3_str
+from drake_models.shared.utils.sdf_helpers import (
+    add_collision_filter_group,
+    add_ground_plane_contact,
+    serialize_model,
+    vec3_str,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -145,6 +150,70 @@ class ExerciseModelBuilder(ABC):
             grip_offset,
         )
 
+    @staticmethod
+    def _add_collision_filters(model: ET.Element) -> None:
+        """Add collision exclusion filters for adjacent body segments.
+
+        Drake uses ``<drake:collision_filter_group>`` to prevent collision
+        detection between segments that are connected by joints. Without
+        these filters, adjacent links would interpenetrate at joint limits.
+        """
+        # Adjacent segment pairs that should not collide
+        adjacent_pairs = [
+            ("torso_pelvis", ["pelvis", "torso"]),
+            ("torso_head", ["torso", "head"]),
+        ]
+        for side in ("l", "r"):
+            adjacent_pairs.extend(
+                [
+                    (
+                        f"hip_{side}",
+                        [
+                            "pelvis",
+                            f"thigh_{side}",
+                            f"hip_{side}_virtual_1",
+                            f"hip_{side}_virtual_2",
+                        ],
+                    ),
+                    (
+                        f"knee_{side}",
+                        [f"thigh_{side}", f"shank_{side}"],
+                    ),
+                    (
+                        f"ankle_{side}",
+                        [
+                            f"shank_{side}",
+                            f"foot_{side}",
+                            f"ankle_{side}_virtual_1",
+                        ],
+                    ),
+                    (
+                        f"shoulder_{side}",
+                        [
+                            "torso",
+                            f"upper_arm_{side}",
+                            f"shoulder_{side}_virtual_1",
+                            f"shoulder_{side}_virtual_2",
+                        ],
+                    ),
+                    (
+                        f"elbow_{side}",
+                        [f"upper_arm_{side}", f"forearm_{side}"],
+                    ),
+                    (
+                        f"wrist_{side}",
+                        [
+                            f"forearm_{side}",
+                            f"hand_{side}",
+                            f"wrist_{side}_virtual_1",
+                        ],
+                    ),
+                ]
+            )
+        for group_name, members in adjacent_pairs:
+            add_collision_filter_group(model, name=group_name, members=members)
+        logger.debug("Added %d collision filter groups", len(adjacent_pairs))
+
     def build(self) -> str:
         """Build the complete SDF model XML and return as string.
 
@@ -162,6 +231,9 @@ class ExerciseModelBuilder(ABC):
         # Static flag (false — this is a dynamic model)
         ET.SubElement(model, "static").text = "false"
 
+        # Ground plane with hydroelastic contact
+        add_ground_plane_contact(model)
+
         # Build body
         body_links = create_full_body(
             model, self.config.body_spec, pelvis_joint_type=self.pelvis_joint_type
@@ -175,6 +247,9 @@ class ExerciseModelBuilder(ABC):
 
         # Exercise-specific initial pose
         self.set_initial_pose(model)
+
+        # Collision exclusion filters for adjacent body segments
+        self._add_collision_filters(model)
 
         xml_str = serialize_model(root)
 

--- a/src/drake_models/exercises/bench_press/bench_press_model.py
+++ b/src/drake_models/exercises/bench_press/bench_press_model.py
@@ -26,6 +26,7 @@ from drake_models.shared.barbell import BarbellSpec
 from drake_models.shared.body import BodyModelSpec
 from drake_models.shared.utils.geometry import rectangular_prism_inertia
 from drake_models.shared.utils.sdf_helpers import (
+    add_contact_geometry,
     add_fixed_joint,
     add_link,
     make_box_geometry,
@@ -112,6 +113,20 @@ class BenchPressModelBuilder(ExerciseModelBuilder):
             child="bench_pad",
             pose=(0, 0, pad_z_center, 0, 0, 0),
         )
+
+        # Contact geometry on top surface of bench pad
+        add_contact_geometry(
+            bench_link,
+            name="bench_pad_contact",
+            geometry=make_box_geometry(
+                BENCH_PAD_LENGTH,
+                BENCH_PAD_WIDTH,
+                BENCH_PAD_THICKNESS,
+            ),
+            pose=(0, 0, 0, 0, 0, 0),
+            hydroelastic_modulus=1e8,
+        )
+
         logger.debug("Added bench pad welded to world at z=%.3f m", pad_z_center)
         return bench_link
 

--- a/src/drake_models/shared/body/body_model.py
+++ b/src/drake_models/shared/body/body_model.py
@@ -46,6 +46,7 @@ from drake_models.shared.utils.geometry import (
     rectangular_prism_inertia,
 )
 from drake_models.shared.utils.sdf_helpers import (
+    add_contact_geometry,
     add_floating_joint,
     add_link,
     add_revolute_joint,
@@ -113,6 +114,11 @@ ANKLE_FLEX_LOWER: float = -0.3491  # -20 degrees
 ANKLE_FLEX_UPPER: float = 0.8727  # +50 degrees
 ANKLE_INVERT_LOWER: float = -0.3491  # -20 degrees
 ANKLE_INVERT_UPPER: float = 0.3491  # +20 degrees
+
+# Foot sole contact geometry dimensions (meters).
+FOOT_CONTACT_LENGTH: float = 0.26  # along X (anterior-posterior)
+FOOT_CONTACT_WIDTH: float = 0.10  # along Y (medial-lateral)
+FOOT_CONTACT_HEIGHT: float = 0.02  # along Z (thickness)
 
 
 @dataclass(frozen=True)
@@ -595,5 +601,21 @@ def create_full_body(
             second_label="invert",
         )
     )
+
+    # --- Foot sole contact geometry (hydroelastic) ---
+    _ft_mass, ft_len, _ft_rad = _seg(spec, "foot")
+    for side in ("l", "r"):
+        foot_link = links[f"foot_{side}"]
+        add_contact_geometry(
+            foot_link,
+            name=f"foot_{side}_contact",
+            geometry=make_box_geometry(
+                FOOT_CONTACT_LENGTH,
+                FOOT_CONTACT_WIDTH,
+                FOOT_CONTACT_HEIGHT,
+            ),
+            pose=(0, 0, -ft_len - FOOT_CONTACT_HEIGHT / 2.0, 0, 0, 0),
+        )
+    logger.debug("Added foot sole contact geometry (both sides)")
 
     return links

--- a/src/drake_models/shared/utils/sdf_helpers.py
+++ b/src/drake_models/shared/utils/sdf_helpers.py
@@ -12,7 +12,18 @@ import logging
 import math
 import xml.etree.ElementTree as ET
 
+# Register Drake's XML namespace so that elements with the ``drake:`` prefix
+# serialize correctly.  The URI follows the convention used by Drake's own SDF
+# extensions (see drake.mit.edu).
+DRAKE_NS = "drake.mit.edu"
+ET.register_namespace("drake", DRAKE_NS)
+
 logger = logging.getLogger(__name__)
+
+
+def _drake_tag(local: str) -> str:
+    """Return a fully-qualified tag name in the Drake namespace."""
+    return f"{{{DRAKE_NS}}}{local}"
 
 
 def vec3_str(x: float, y: float, z: float) -> str:
@@ -204,6 +215,136 @@ def add_fixed_joint(
     ET.SubElement(joint, "child").text = child
     ET.SubElement(joint, "pose").text = pose_str(*pose)
     return joint
+
+
+def add_contact_geometry(
+    link: ET.Element,
+    *,
+    name: str,
+    geometry: ET.Element,
+    pose: tuple[float, float, float, float, float, float] = (0, 0, 0, 0, 0, 0),
+    mu_static: float = 0.8,
+    mu_dynamic: float = 0.6,
+    hydroelastic_modulus: float = 1e7,
+    hunt_crossley_dissipation: float = 1.0,
+) -> ET.Element:
+    """Append a <collision> with Drake hydroelastic proximity properties to *link*.
+
+    Creates a collision element with ``<drake:proximity_properties>`` containing
+    compliant hydroelastic contact parameters, friction coefficients, and
+    Hunt-Crossley dissipation.
+
+    Args:
+        link: The SDF link element to append the collision to.
+        name: Name for the collision element.
+        geometry: SDF ``<geometry>`` element (e.g. from ``make_box_geometry``).
+        pose: 6-tuple (x, y, z, roll, pitch, yaw) for collision pose.
+        mu_static: Static friction coefficient.
+        mu_dynamic: Dynamic friction coefficient.
+        hydroelastic_modulus: Hydroelastic modulus in Pa.
+        hunt_crossley_dissipation: Hunt-Crossley dissipation coefficient.
+
+    Returns:
+        The created ``<collision>`` element.
+    """
+    collision = ET.SubElement(link, "collision", name=name)
+    ET.SubElement(collision, "pose").text = pose_str(*pose)
+    collision.append(geometry)
+
+    prox = ET.SubElement(collision, _drake_tag("proximity_properties"))
+    ET.SubElement(prox, _drake_tag("compliant_hydroelastic"))
+    ET.SubElement(
+        prox, _drake_tag("hydroelastic_modulus")
+    ).text = f"{hydroelastic_modulus:.0f}"
+    ET.SubElement(
+        prox, _drake_tag("hunt_crossley_dissipation")
+    ).text = f"{hunt_crossley_dissipation:.1f}"
+    ET.SubElement(prox, _drake_tag("mu_static")).text = f"{mu_static:.1f}"
+    ET.SubElement(prox, _drake_tag("mu_dynamic")).text = f"{mu_dynamic:.1f}"
+
+    return collision
+
+
+def add_ground_plane_contact(
+    model: ET.Element,
+    *,
+    mu_static: float = 0.8,
+    mu_dynamic: float = 0.6,
+) -> ET.Element:
+    """Add an infinite half-space ground plane with rigid hydroelastic contact.
+
+    Creates a ``ground_plane`` link welded to world at Z=0. The collision
+    uses ``<drake:rigid_hydroelastic/>`` (the ground is infinitely stiff)
+    and a large box to approximate the half-space.
+
+    Args:
+        model: SDF model element to append to.
+        mu_static: Static friction coefficient.
+        mu_dynamic: Dynamic friction coefficient.
+
+    Returns:
+        The created ground plane link element.
+    """
+    ground_link = add_link(
+        model,
+        name="ground_plane",
+        mass=1e-6,
+        mass_center=(0, 0, 0),
+        inertia_xx=1e-6,
+        inertia_yy=1e-6,
+        inertia_zz=1e-6,
+    )
+
+    # Large box approximating infinite half-space (100m x 100m x 0.1m)
+    collision = ET.SubElement(ground_link, "collision", name="ground_plane_collision")
+    ET.SubElement(collision, "pose").text = pose_str(0, 0, -0.05, 0, 0, 0)
+    geom = ET.SubElement(collision, "geometry")
+    box = ET.SubElement(geom, "box")
+    ET.SubElement(box, "size").text = vec3_str(100, 100, 0.1)
+
+    prox = ET.SubElement(collision, _drake_tag("proximity_properties"))
+    ET.SubElement(prox, _drake_tag("rigid_hydroelastic"))
+    ET.SubElement(prox, _drake_tag("mu_static")).text = f"{mu_static:.1f}"
+    ET.SubElement(prox, _drake_tag("mu_dynamic")).text = f"{mu_dynamic:.1f}"
+
+    # Weld ground plane to world at Z=0
+    add_fixed_joint(
+        model,
+        name="ground_plane_weld",
+        parent="world",
+        child="ground_plane",
+        pose=(0, 0, 0, 0, 0, 0),
+    )
+
+    logger.debug("Added ground plane with rigid hydroelastic contact")
+    return ground_link
+
+
+def add_collision_filter_group(
+    model: ET.Element,
+    *,
+    name: str,
+    members: list[str],
+) -> ET.Element:
+    """Add a Drake collision filter group to exclude self-collision.
+
+    Creates a ``<drake:collision_filter_group>`` that ignores collisions
+    between all members of the group.
+
+    Args:
+        model: SDF model element to append to.
+        name: Name of the collision filter group.
+        members: List of link names to include in the group.
+
+    Returns:
+        The created filter group element.
+    """
+    group = ET.SubElement(model, _drake_tag("collision_filter_group"), name=name)
+    for member in members:
+        ET.SubElement(group, _drake_tag("member")).text = member
+    ET.SubElement(group, _drake_tag("ignored_collision_filter_group")).text = name
+
+    return group
 
 
 def serialize_model(root: ET.Element) -> str:

--- a/tests/unit/shared/test_ground_contact.py
+++ b/tests/unit/shared/test_ground_contact.py
@@ -1,0 +1,262 @@
+"""Tests for ground contact models and hydroelastic contact properties."""
+
+import xml.etree.ElementTree as ET
+from typing import Any
+
+import pytest
+
+from drake_models.shared.body import create_full_body
+from drake_models.shared.utils.sdf_helpers import (
+    DRAKE_NS,
+    add_collision_filter_group,
+    add_contact_geometry,
+    add_ground_plane_contact,
+    add_link,
+    make_box_geometry,
+)
+
+# Namespace map for XPath queries on Drake-namespaced elements.
+_NS = {"drake": DRAKE_NS}
+
+
+def _dtag(local: str) -> str:
+    """Build a fully-qualified tag in the Drake namespace (for tag comparison)."""
+    return f"{{{DRAKE_NS}}}{local}"
+
+
+class TestAddContactGeometry:
+    @pytest.fixture()
+    def link(self) -> ET.Element:
+        model = ET.Element("model", name="test")
+        return add_link(
+            model,
+            name="test_link",
+            mass=1.0,
+            mass_center=(0, 0, 0),
+            inertia_xx=0.1,
+            inertia_yy=0.1,
+            inertia_zz=0.1,
+        )
+
+    def test_creates_collision_element(self, link: Any) -> None:
+        geom = make_box_geometry(0.26, 0.10, 0.02)
+        collision = add_contact_geometry(link, name="foot_contact", geometry=geom)
+        assert collision.tag == "collision"
+        assert collision.get("name") == "foot_contact"
+
+    def test_has_geometry(self, link: Any) -> None:
+        geom = make_box_geometry(0.26, 0.10, 0.02)
+        collision = add_contact_geometry(link, name="foot_contact", geometry=geom)
+        box = collision.find("geometry/box")
+        assert box is not None
+
+    def test_has_drake_proximity_properties(self, link: Any) -> None:
+        geom = make_box_geometry(0.26, 0.10, 0.02)
+        collision = add_contact_geometry(link, name="foot_contact", geometry=geom)
+        prox = collision.find("drake:proximity_properties", _NS)
+        assert prox is not None
+
+    def test_has_compliant_hydroelastic(self, link: Any) -> None:
+        geom = make_box_geometry(0.26, 0.10, 0.02)
+        collision = add_contact_geometry(link, name="foot_contact", geometry=geom)
+        prox = collision.find("drake:proximity_properties", _NS)
+        assert prox.find("drake:compliant_hydroelastic", _NS) is not None
+
+    def test_has_hydroelastic_modulus(self, link: Any) -> None:
+        geom = make_box_geometry(0.26, 0.10, 0.02)
+        collision = add_contact_geometry(
+            link,
+            name="foot_contact",
+            geometry=geom,
+            hydroelastic_modulus=1e7,
+        )
+        prox = collision.find("drake:proximity_properties", _NS)
+        modulus = prox.find("drake:hydroelastic_modulus", _NS)
+        assert modulus is not None
+        assert float(modulus.text) == pytest.approx(1e7)
+
+    def test_has_friction_coefficients(self, link: Any) -> None:
+        geom = make_box_geometry(0.26, 0.10, 0.02)
+        collision = add_contact_geometry(
+            link,
+            name="foot_contact",
+            geometry=geom,
+            mu_static=0.8,
+            mu_dynamic=0.6,
+        )
+        prox = collision.find("drake:proximity_properties", _NS)
+        assert float(prox.find("drake:mu_static", _NS).text) == pytest.approx(0.8)
+        assert float(prox.find("drake:mu_dynamic", _NS).text) == pytest.approx(0.6)
+
+    def test_has_dissipation(self, link: Any) -> None:
+        geom = make_box_geometry(0.26, 0.10, 0.02)
+        collision = add_contact_geometry(
+            link,
+            name="foot_contact",
+            geometry=geom,
+            hunt_crossley_dissipation=1.0,
+        )
+        prox = collision.find("drake:proximity_properties", _NS)
+        diss = prox.find("drake:hunt_crossley_dissipation", _NS)
+        assert diss is not None
+        assert float(diss.text) == pytest.approx(1.0)
+
+    def test_has_pose(self, link: Any) -> None:
+        geom = make_box_geometry(0.26, 0.10, 0.02)
+        collision = add_contact_geometry(
+            link,
+            name="foot_contact",
+            geometry=geom,
+            pose=(0, 0, -0.05, 0, 0, 0),
+        )
+        pose = collision.find("pose")
+        assert pose is not None
+        assert "-0.050000" in pose.text
+
+    def test_custom_friction(self, link: Any) -> None:
+        geom = make_box_geometry(0.26, 0.10, 0.02)
+        collision = add_contact_geometry(
+            link,
+            name="fc",
+            geometry=geom,
+            mu_static=1.2,
+            mu_dynamic=0.9,
+        )
+        prox = collision.find("drake:proximity_properties", _NS)
+        assert float(prox.find("drake:mu_static", _NS).text) == pytest.approx(1.2)
+        assert float(prox.find("drake:mu_dynamic", _NS).text) == pytest.approx(0.9)
+
+
+class TestAddGroundPlaneContact:
+    @pytest.fixture()
+    def model(self) -> ET.Element:
+        return ET.Element("model", name="test")
+
+    def test_creates_ground_plane_link(self, model: Any) -> None:
+        ground = add_ground_plane_contact(model)
+        assert ground.tag == "link"
+        assert ground.get("name") == "ground_plane"
+
+    def test_has_collision(self, model: Any) -> None:
+        ground = add_ground_plane_contact(model)
+        collision = ground.find("collision")
+        assert collision is not None
+        assert collision.get("name") == "ground_plane_collision"
+
+    def test_has_rigid_hydroelastic(self, model: Any) -> None:
+        ground = add_ground_plane_contact(model)
+        collision = ground.find("collision")
+        prox = collision.find("drake:proximity_properties", _NS)
+        assert prox is not None
+        assert prox.find("drake:rigid_hydroelastic", _NS) is not None
+
+    def test_has_friction(self, model: Any) -> None:
+        ground = add_ground_plane_contact(model)
+        collision = ground.find("collision")
+        prox = collision.find("drake:proximity_properties", _NS)
+        assert float(prox.find("drake:mu_static", _NS).text) == pytest.approx(0.8)
+        assert float(prox.find("drake:mu_dynamic", _NS).text) == pytest.approx(0.6)
+
+    def test_welded_to_world(self, model: Any) -> None:
+        add_ground_plane_contact(model)
+        joints = model.findall("joint")
+        weld = None
+        for j in joints:
+            if j.get("name") == "ground_plane_weld":
+                weld = j
+                break
+        assert weld is not None
+        assert weld.get("type") == "fixed"
+        assert weld.find("parent").text == "world"
+        assert weld.find("child").text == "ground_plane"
+
+    def test_ground_box_geometry(self, model: Any) -> None:
+        ground = add_ground_plane_contact(model)
+        collision = ground.find("collision")
+        box = collision.find("geometry/box")
+        assert box is not None
+        size = box.find("size").text
+        assert "100.000000" in size
+
+
+class TestFootContactGeometry:
+    @pytest.fixture()
+    def model(self) -> ET.Element:
+        return ET.Element("model", name="test")
+
+    def test_foot_links_have_contact_collision(self, model: Any) -> None:
+        """Both foot links must have a contact collision element."""
+        create_full_body(model)
+        for side in ("l", "r"):
+            foot = model.find(f"link[@name='foot_{side}']")
+            assert foot is not None
+            collisions = foot.findall("collision")
+            contact_names = [c.get("name") for c in collisions]
+            assert f"foot_{side}_contact" in contact_names, (
+                f"foot_{side} missing contact collision"
+            )
+
+    def test_foot_contact_has_box_geometry(self, model: Any) -> None:
+        create_full_body(model)
+        for side in ("l", "r"):
+            foot = model.find(f"link[@name='foot_{side}']")
+            contact = None
+            for c in foot.findall("collision"):
+                if c.get("name") == f"foot_{side}_contact":
+                    contact = c
+                    break
+            assert contact is not None
+            box = contact.find("geometry/box")
+            assert box is not None
+            size = box.find("size").text
+            assert "0.260000" in size
+            assert "0.100000" in size
+            assert "0.020000" in size
+
+    def test_foot_contact_has_drake_properties(self, model: Any) -> None:
+        create_full_body(model)
+        for side in ("l", "r"):
+            foot = model.find(f"link[@name='foot_{side}']")
+            contact = None
+            for c in foot.findall("collision"):
+                if c.get("name") == f"foot_{side}_contact":
+                    contact = c
+                    break
+            assert contact is not None
+            prox = contact.find("drake:proximity_properties", _NS)
+            assert prox is not None
+            assert prox.find("drake:compliant_hydroelastic", _NS) is not None
+            assert prox.find("drake:hydroelastic_modulus", _NS) is not None
+            assert prox.find("drake:mu_static", _NS) is not None
+            assert prox.find("drake:mu_dynamic", _NS) is not None
+
+
+class TestCollisionFilterGroup:
+    @pytest.fixture()
+    def model(self) -> ET.Element:
+        return ET.Element("model", name="test")
+
+    def test_creates_filter_group(self, model: Any) -> None:
+        group = add_collision_filter_group(
+            model, name="hip_l", members=["pelvis", "thigh_l"]
+        )
+        assert group.tag == _dtag("collision_filter_group")
+        assert group.get("name") == "hip_l"
+
+    def test_has_members(self, model: Any) -> None:
+        group = add_collision_filter_group(
+            model,
+            name="knee_r",
+            members=["thigh_r", "shank_r"],
+        )
+        members = [m.text for m in group.findall("drake:member", _NS)]
+        assert "thigh_r" in members
+        assert "shank_r" in members
+
+    def test_ignores_self(self, model: Any) -> None:
+        group = add_collision_filter_group(
+            model, name="hip_l", members=["pelvis", "thigh_l"]
+        )
+        ignored = group.find("drake:ignored_collision_filter_group", _NS)
+        assert ignored is not None
+        assert ignored.text == "hip_l"


### PR DESCRIPTION
## Summary
- Add foot sole contact geometry (compliant hydroelastic, box 0.26x0.10x0.02m) to both foot links in the body model
- Add ground plane with rigid hydroelastic contact (100m x 100m half-space welded to world)
- Add collision filter groups for all adjacent body segments to prevent self-collision
- Add bench pad contact geometry with hydroelastic properties
- New SDF helpers: `add_contact_geometry`, `add_ground_plane_contact`, `add_collision_filter_group` with proper Drake XML namespace support
- 21 new unit tests covering contact geometry, ground plane, foot contact, and collision filters

## Test plan
- [x] All 21 new ground contact tests pass
- [x] All 279 unit tests pass (no regressions)
- [x] All 64 integration tests pass (1 skipped as expected)
- [x] Ruff lint: zero violations
- [x] Ruff format: zero diffs
- [x] XML serialization produces valid SDF with `drake:` namespace prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)