### PR TITLE
fix: A-O assessment remediation -- CLAUDE.md, docstrings, logging

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,80 @@
+# CLAUDE.md -- Drake_Models
+
+## What This Is
+
+Drake multibody simulation models for classical barbell exercises (squat,
+deadlift, bench press, snatch, clean & jerk) plus gait and sit-to-stand.
+Models are generated as SDFormat (SDF 1.8) XML and can be loaded by the
+Drake physics engine for biomechanical analysis.
+
+## Key Directories
+
+- `src/drake_models/exercises/` -- exercise-specific model builders
+- `src/drake_models/shared/` -- shared body, barbell, geometry, contracts
+- `src/drake_models/optimization/` -- trajectory optimization and IK
+- `tests/unit/` -- unit tests (no pydrake required)
+- `tests/integration/` -- integration tests (XML validation, optional pydrake)
+- `tests/parity/` -- cross-implementation parity checks
+- `rust_core/` -- Rust FFI core (Cargo workspace)
+- `examples/` -- usage examples and model generation scripts
+
+## Python and Tooling
+
+- **Python 3.10+**. Use `python3`.
+- **Formatter:** `ruff format` (line length 88).
+- **Linter:** `ruff check` with rules: E, F, I, UP, B, T201, SIM, C4, PIE, PLE, FURB, RSE, LOG, PERF, RET.
+- **Type checker:** `mypy src` (strict: `disallow_untyped_defs = true`).
+- **Tests:** pytest with 80% coverage minimum.
+
+## Development Commands
+
+```bash
+ruff check src scripts tests                    # lint
+ruff format --check src scripts tests           # format check
+mypy src                                        # type check
+python3 -m pytest tests/ -v                     # run all tests
+python3 -m pytest --cov=src --cov-fail-under=80 # tests with coverage
+python3 -m drake_models squat --mass 80         # generate a model
+```
+
+## CI Requirements (All Must Pass)
+
+1. `ruff check` -- zero violations
+2. `ruff format --check` -- zero diffs
+3. `mypy src` -- zero errors
+4. No TODO/FIXME in source unless tracked by a GitHub issue
+5. `pip-audit` -- no known vulnerabilities (advisory ignores configured)
+6. `bandit -r src/` -- no high-severity findings
+7. pytest with **80% coverage minimum** across Python 3.10, 3.11, 3.12
+
+## Architecture Principles
+
+- **TDD:** Tests first. 80% coverage floor enforced in CI.
+- **DbC:** Preconditions in `shared/contracts/preconditions.py`, postconditions in `postconditions.py`. Inputs raise `ValueError`, output violations raise `AssertionError`.
+- **DRY:** Geometry, inertia, XML generation live once in `shared/`. Exercise builders inherit from `ExerciseModelBuilder` base class.
+- **LoD:** Callers use public APIs only. Complex internals stay behind module boundaries.
+
+## Drake-Specific Conventions
+
+- **SDFormat 1.8** model description format.
+- **Z-up**: vertical = Z, forward = X, gravity = (0, 0, -9.80665).
+- Bodies are `<link>` with `<inertial>`, `<visual>`, `<collision>`.
+- Joints: `revolute`, `fixed`, `floating`.
+- Models generate SDF XML strings; tests verify XML without pydrake.
+
+## Coding Standards
+
+- `from __future__ import annotations` in every module.
+- Type hints on all public function signatures.
+- Google-style docstrings on all public modules, classes, and functions.
+- No `print()` in `src/` -- use `logging`.
+- No f-strings in logging calls -- use `%s` lazy formatting.
+- No wildcard imports.
+- No bare `except:` -- always specify exception types.
+
+## Git Workflow
+
+- Branch from `main`. Naming: `fix/issue-XXXX-desc` or `feat/desc`.
+- PRs require CI green before merge.
+- Conventional commits: `feat:`, `fix:`, `test:`, `docs:`, `refactor:`.
+- Never force-push to `main`.

--- a/src/drake_models/exercises/bench_press/bench_press_model.py
+++ b/src/drake_models/exercises/bench_press/bench_press_model.py
@@ -74,6 +74,7 @@ class BenchPressModelBuilder(ExerciseModelBuilder):
 
     @property
     def exercise_name(self) -> str:
+        """Return the canonical exercise name for the bench press model."""
         return "bench_press"
 
     @property

--- a/src/drake_models/exercises/clean_and_jerk/clean_and_jerk_model.py
+++ b/src/drake_models/exercises/clean_and_jerk/clean_and_jerk_model.py
@@ -61,6 +61,7 @@ class CleanAndJerkModelBuilder(ExerciseModelBuilder):
 
     @property
     def exercise_name(self) -> str:
+        """Return the canonical exercise name for the clean and jerk model."""
         return "clean_and_jerk"
 
     def attach_barbell(

--- a/src/drake_models/exercises/deadlift/deadlift_model.py
+++ b/src/drake_models/exercises/deadlift/deadlift_model.py
@@ -48,6 +48,7 @@ class DeadliftModelBuilder(ExerciseModelBuilder):
 
     @property
     def exercise_name(self) -> str:
+        """Return the canonical exercise name for the deadlift model."""
         return "deadlift"
 
     def attach_barbell(

--- a/src/drake_models/exercises/gait/gait_model.py
+++ b/src/drake_models/exercises/gait/gait_model.py
@@ -47,6 +47,7 @@ class GaitModelBuilder(ExerciseModelBuilder):
 
     @property
     def exercise_name(self) -> str:
+        """Return the canonical exercise name for the gait model."""
         return "gait"
 
     def attach_barbell(

--- a/src/drake_models/exercises/sit_to_stand/sit_to_stand_model.py
+++ b/src/drake_models/exercises/sit_to_stand/sit_to_stand_model.py
@@ -60,6 +60,7 @@ class SitToStandModelBuilder(ExerciseModelBuilder):
 
     @property
     def exercise_name(self) -> str:
+        """Return the canonical exercise name for the sit-to-stand model."""
         return "sit_to_stand"
 
     def _add_chair_body(self, model: ET.Element) -> ET.Element:

--- a/src/drake_models/exercises/snatch/snatch_model.py
+++ b/src/drake_models/exercises/snatch/snatch_model.py
@@ -55,6 +55,7 @@ class SnatchModelBuilder(ExerciseModelBuilder):
 
     @property
     def exercise_name(self) -> str:
+        """Return the canonical exercise name for the snatch model."""
         return "snatch"
 
     def attach_barbell(

--- a/src/drake_models/exercises/squat/squat_model.py
+++ b/src/drake_models/exercises/squat/squat_model.py
@@ -53,6 +53,7 @@ class SquatModelBuilder(ExerciseModelBuilder):
 
     @property
     def exercise_name(self) -> str:
+        """Return the canonical exercise name for the back squat model."""
         return "back_squat"
 
     def attach_barbell(

--- a/src/drake_models/shared/theme.py
+++ b/src/drake_models/shared/theme.py
@@ -18,7 +18,7 @@ try:
         """Apply the global shared plot theme to a Matplotlib axis."""
         _style_axis(ax)
 
-    logger.debug(f"Loaded shared plot theme: {theme.name}")
+    logger.debug("Loaded shared plot theme: %s", theme.name)
 
 except ImportError:
     logger.warning(


### PR DESCRIPTION
## Summary
- Created `CLAUDE.md` with complete project conventions, dev commands, CI requirements, and coding standards (fixes #71)
- Added missing Google-style docstrings to all 7 `exercise_name` property overrides across exercise model builders (fixes #72)
- Replaced eager f-string with lazy `%s` formatting in `theme.py` logger call (fixes #73)

## A-O Assessment Grades

| Category | Grade | Notes |
|----------|-------|-------|
| **A -- Project Organization** | **A** | Clean package layout, `pyproject.toml` well-configured, Hatch build, clear exercise/shared/optimization separation |
| **B -- Documentation** | **A-** | Comprehensive docstrings, AGENTS.md, README, CONTRIBUTING, CHANGELOG. Minor: 7 `exercise_name` overrides lacked docstrings (now fixed) |
| **C -- Testing** | **A** | 91.3% coverage (target 80%), unit/integration/parity/hypothesis tests, multi-Python CI matrix, edge-case anthropometrics |
| **D -- Robustness / DbC** | **A** | Dedicated `contracts/` module with preconditions and postconditions, frozen dataclasses, `__post_init__` validation, no bare excepts |
| **E -- Performance** | **A-** | One f-string in logging (now fixed). Otherwise clean: lazy logging, efficient numpy operations, no unnecessary allocations |
| **F -- Craftsmanship / DRY** | **A** | Strong DRY via `ExerciseModelBuilder` base class, shared geometry/SDF helpers, consistent patterns. Ruff + mypy strict. Two files >500 lines but they are coherent (data-heavy objectives + body model constants) |
| **G -- Dependencies / Security** | **A** | Dependabot configured, `pip-audit` and `bandit` in CI, minimal deps (numpy, matplotlib), pinned CI tool versions |
| **H -- Automation / CI** | **A** | Multi-stage Dockerfile, GitHub Actions with quality gate + test matrix, pre-commit hooks, concurrency groups |
| **P -- Agentic Usability** | **A-** | AGENTS.md present but CLAUDE.md was missing (now created). Clear dev commands and standards documented |

## Test plan
- [x] `ruff check src scripts tests` -- zero violations
- [x] `ruff format --check src scripts tests` -- zero diffs
- [x] `mypy src` -- zero errors
- [x] `pytest --cov=src --cov-fail-under=80` -- 91.3% coverage, all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)