### PR TITLE
Fix snatch docstring: 120 kg -> 100 kg

### DIFF
--- a/src/drake_models/exercises/snatch/snatch_model.py
+++ b/src/drake_models/exercises/snatch/snatch_model.py
@@ -103,7 +103,7 @@ def build_snatch_model(
 ) -> str:
     """Convenience function to build a snatch model SDF string.
 
-    Default: 80 kg person, 120 kg total barbell (competitive 96 kg class).
+    Default: 80 kg person, 100 kg total barbell (competitive 96 kg class).
     """
     config = ExerciseConfig(
         body_spec=BodyModelSpec(total_mass=body_mass, height=height),


### PR DESCRIPTION
## Summary
- Corrected the `make_snatch_sdf` docstring from "120 kg total barbell" to "100 kg total barbell"
- The defaults are 20 kg bar + 2 x 40 kg plates = 100 kg, not 120 kg

Closes #54

## Test plan
- [x] All 615 existing tests pass before and after the change
- [x] Verified `BarbellSpec.mens_olympic` uses a 20 kg bar, confirming 20 + 2(40) = 100 kg

🤖 Generated with [Claude Code](https://claude.com/claude-code)