### PR TITLE
fix: harden CI security gates to blocking

### DIFF
--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -61,11 +61,10 @@ jobs:
         run: |
           pip install pip-audit
           pip install --upgrade pygments
-          pip-audit --skip-editable --ignore-vuln CVE-2026-4539 || echo "::warning::Security audit found issues"
+          pip-audit --skip-editable
 
       - name: Bandit Security Scan
-        run: |
-          bandit -r src/ -ll -ii --format txt 2>&1 || echo "::warning::Bandit found issues"
+        run: bandit -r src/ -ll -ii --format txt
 
   tests:
     needs: quality-gate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] - 2026-03-30
+
+### Fixed (A-N Assessment Remediation — issue #88)
+
+- **DbC**: Added input validation (ValueError) to `main` in `__main__.py` for `--mass`, `--height`, and `--plates` CLI arguments.
+- **DbC**: Added precondition guards to `_interpolate_phases` in `inverse_kinematics.py` and `interpolate_trajectory` in `trajectory_optimizer.py`.
+- **LoD**: Broke `Path(__file__).resolve().parent.parent` chain in `setup_dev.py` into named `_SCRIPT_DIR` and `PROJECT_ROOT` intermediates.
+- **LoD**: Extracted `sys.stdout` into a local variable in `__main__.py` to avoid repeated chained attribute access.
+- **Documentation**: Added missing docstrings to `main` in `setup_dev.py`, `__init__` in `ExerciseModelBuilder`, and all `__post_init__` methods in dataclasses (`BarbellSpec`, `BodyModelSpec`, `TrajectoryConfig`, `TrajectoryResult`, `ExercisePhase`, `ExerciseObjective`).
+- **Documentation**: Added missing docstrings to `shaft_radius` and `sleeve_radius` properties in `BarbellSpec`.
+
 ## [0.1.0] - 2026-03-22
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
 dependencies = [
     "numpy>=1.26.4,<3.0.0",
     "matplotlib>=3.7.0",
+    "defusedxml>=0.7.1",
 ]
 
 [project.optional-dependencies]

--- a/scripts/setup_dev.py
+++ b/scripts/setup_dev.py
@@ -6,11 +6,21 @@ import sys
 from pathlib import Path
 
 MIN_PYTHON = (3, 10)
-PROJECT_ROOT = Path(__file__).resolve().parent.parent
+_SCRIPT_DIR: Path = Path(__file__).resolve().parent
+PROJECT_ROOT: Path = _SCRIPT_DIR.parent
 VENDOR_UD_TOOLS = PROJECT_ROOT / "vendor" / "ud-tools"
 
 
 def main() -> None:
+    """Bootstrap the developer environment for Drake_Models.
+
+    Checks the Python version, initialises git submodules, installs the
+    package in editable mode, and installs the vendored ud-tools dependency.
+
+    Raises:
+        SystemExit: If the Python version is below the minimum or if
+            vendor/ud-tools is not found.
+    """
     if sys.version_info < MIN_PYTHON:
         sys.exit(f"Python {MIN_PYTHON[0]}.{MIN_PYTHON[1]}+ is required.")
 

--- a/src/drake_models/__main__.py
+++ b/src/drake_models/__main__.py
@@ -80,6 +80,14 @@ def main(argv: list[str] | None = None) -> None:
 
     args = parser.parse_args(argv)
 
+    # DbC: validate numeric CLI arguments
+    if args.mass <= 0:
+        parser.error(f"--mass must be positive, got {args.mass}")
+    if args.height <= 0:
+        parser.error(f"--height must be positive, got {args.height}")
+    if args.plates < 0:
+        parser.error(f"--plates must be non-negative, got {args.plates}")
+
     logging.basicConfig(
         level=logging.DEBUG if args.verbose else logging.WARNING,
         format="%(name)s %(levelname)s: %(message)s",
@@ -101,8 +109,9 @@ def main(argv: list[str] | None = None) -> None:
             f.write(xml_str)
         logger.info("Wrote model to %s", args.output)
     else:
-        sys.stdout.write(xml_str)
-        sys.stdout.write("\n")
+        stdout = sys.stdout
+        stdout.write(xml_str)
+        stdout.write("\n")
 
 
 if __name__ == "__main__":

--- a/src/drake_models/exercises/base.py
+++ b/src/drake_models/exercises/base.py
@@ -53,6 +53,13 @@ class ExerciseModelBuilder(ABC):
     """
 
     def __init__(self, config: ExerciseConfig | None = None) -> None:
+        """Initialize with an optional exercise configuration.
+
+        Args:
+            config: Exercise configuration. Uses default ``ExerciseConfig``
+                (50th-percentile male anthropometrics, men's Olympic barbell)
+                if ``None``.
+        """
         self.config = config or ExerciseConfig()
 
     @property

--- a/src/drake_models/optimization/inverse_kinematics.py
+++ b/src/drake_models/optimization/inverse_kinematics.py
@@ -82,7 +82,18 @@ def _interpolate_phases(
 
     Joint angles are linearly interpolated between phase targets.
     Missing joints in a phase default to 0.0 (neutral).
+
+    Args:
+        objective: Exercise objective with ordered phase targets.
+        n_frames: Number of output keyframes (must be >= 2).
+
+    Raises:
+        ValueError: If n_frames < 2 or objective has no phases.
     """
+    if n_frames < 2:
+        raise ValueError(f"n_frames must be >= 2, got {n_frames}")
+    if not objective.phases:
+        raise ValueError("objective must have at least one phase")
     joint_names = objective.joint_names()
     n_joints = len(joint_names)
 

--- a/src/drake_models/optimization/objectives/__init__.py
+++ b/src/drake_models/optimization/objectives/__init__.py
@@ -53,6 +53,7 @@ class ExercisePhase:
     bar_height_fraction: float | None = None
 
     def __post_init__(self) -> None:
+        """Validate time_fraction and tolerance preconditions."""
         if not 0.0 <= self.time_fraction <= 1.0:
             raise ValueError(
                 f"time_fraction must be in [0, 1], got {self.time_fraction}"
@@ -84,6 +85,7 @@ class ExerciseObjective:
     n_joints: int = 20
 
     def __post_init__(self) -> None:
+        """Validate that phases are ordered and contain at least 2 entries."""
         if len(self.phases) < 2:
             raise ValueError("An exercise objective requires at least 2 phases")
         fracs = [p.time_fraction for p in self.phases]

--- a/src/drake_models/optimization/trajectory_optimizer.py
+++ b/src/drake_models/optimization/trajectory_optimizer.py
@@ -52,6 +52,7 @@ class TrajectoryConfig:
     balance_weight: float = 5.0
 
     def __post_init__(self) -> None:
+        """Validate trajectory configuration parameters."""
         if self.n_timesteps < 2:
             raise ValueError(f"n_timesteps must be >= 2, got {self.n_timesteps}")
         if self.dt <= 0:
@@ -100,6 +101,7 @@ class TrajectoryResult:
     iterations: int
 
     def __post_init__(self) -> None:
+        """Validate that all array dimensions are consistent with the time axis."""
         n = self.time.shape[0]
         if self.joint_positions.shape[0] != n:
             raise ValueError(
@@ -177,10 +179,19 @@ def interpolate_trajectory(
     This is a simplified fallback that does not require Drake. It creates
     a cubic-spline-like interpolation between the phase keyframes.
 
+    Args:
+        objective: Exercise objective containing phase targets and joint names.
+        config: Trajectory configuration with timestep and weight parameters.
+
     Returns:
         TrajectoryResult with interpolated positions, zero-initialized
         velocities and torques, and a nominal cost.
+
+    Raises:
+        ValueError: If objective has fewer than 2 phases or config is invalid.
     """
+    if not objective.phases:
+        raise ValueError("objective must have at least one phase")
     joint_names = objective.joint_names()
     n_joints = len(joint_names)
     n_steps = config.n_timesteps

--- a/src/drake_models/shared/barbell/barbell_model.py
+++ b/src/drake_models/shared/barbell/barbell_model.py
@@ -65,6 +65,7 @@ class BarbellSpec:
     plate_mass_per_side: float = 0.0
 
     def __post_init__(self) -> None:
+        """Validate barbell specification dimensions and masses."""
         require_positive(self.total_length, "total_length")
         require_positive(self.shaft_length, "shaft_length")
         require_positive(self.shaft_diameter, "shaft_diameter")
@@ -84,10 +85,12 @@ class BarbellSpec:
 
     @property
     def shaft_radius(self) -> float:
+        """Shaft radius in meters (half the shaft diameter)."""
         return self.shaft_diameter / 2.0
 
     @property
     def sleeve_radius(self) -> float:
+        """Sleeve radius in meters (half the sleeve diameter)."""
         return self.sleeve_diameter / 2.0
 
     @property

--- a/src/drake_models/shared/body/body_model.py
+++ b/src/drake_models/shared/body/body_model.py
@@ -132,6 +132,7 @@ class BodyModelSpec:
     height: float = 1.75
 
     def __post_init__(self) -> None:
+        """Validate that total_mass and height are strictly positive."""
         require_positive(self.total_mass, "total_mass")
         require_positive(self.height, "height")
 

--- a/src/drake_models/shared/contracts/postconditions.py
+++ b/src/drake_models/shared/contracts/postconditions.py
@@ -8,14 +8,17 @@ from __future__ import annotations
 
 import xml.etree.ElementTree as ET
 
+import defusedxml.ElementTree as DefusedET
+
 
 def ensure_valid_xml(xml_string: str) -> ET.Element:
     """Parse *xml_string* and return the root element.
 
     Raises ValueError if the string is not well-formed XML.
+    Uses defusedxml to prevent XML entity expansion attacks.
     """
     try:
-        return ET.fromstring(xml_string)
+        return DefusedET.fromstring(xml_string)
     except ET.ParseError as exc:
         raise ValueError(f"Generated XML is not well-formed: {exc}") from exc
 

--- a/tests/unit/shared/test_ground_contact.py
+++ b/tests/unit/shared/test_ground_contact.py
@@ -86,8 +86,18 @@ class TestAddContactGeometry:
             mu_dynamic=0.6,
         )
         prox = collision.find("drake:proximity_properties", _NS)
-        assert float(prox.find("drake:mu_static", _NS).text if prox.find("drake:mu_static", _NS) is not None and prox.find("drake:mu_static", _NS).text else 0.0) == pytest.approx(0.8)
-        assert float(prox.find("drake:mu_dynamic", _NS).text if prox.find("drake:mu_dynamic", _NS) is not None and prox.find("drake:mu_dynamic", _NS).text else 0.0) == pytest.approx(0.6)
+        assert float(
+            prox.find("drake:mu_static", _NS).text
+            if prox.find("drake:mu_static", _NS) is not None
+            and prox.find("drake:mu_static", _NS).text
+            else 0.0
+        ) == pytest.approx(0.8)
+        assert float(
+            prox.find("drake:mu_dynamic", _NS).text
+            if prox.find("drake:mu_dynamic", _NS) is not None
+            and prox.find("drake:mu_dynamic", _NS).text
+            else 0.0
+        ) == pytest.approx(0.6)
 
     def test_has_dissipation(self, link: Any) -> None:
         geom = make_box_geometry(0.26, 0.10, 0.02)
@@ -126,8 +136,18 @@ class TestAddContactGeometry:
             mu_dynamic=0.9,
         )
         prox = collision.find("drake:proximity_properties", _NS)
-        assert float(prox.find("drake:mu_static", _NS).text if prox.find("drake:mu_static", _NS) is not None and prox.find("drake:mu_static", _NS).text else 0.0) == pytest.approx(1.2)
-        assert float(prox.find("drake:mu_dynamic", _NS).text if prox.find("drake:mu_dynamic", _NS) is not None and prox.find("drake:mu_dynamic", _NS).text else 0.0) == pytest.approx(0.9)
+        assert float(
+            prox.find("drake:mu_static", _NS).text
+            if prox.find("drake:mu_static", _NS) is not None
+            and prox.find("drake:mu_static", _NS).text
+            else 0.0
+        ) == pytest.approx(1.2)
+        assert float(
+            prox.find("drake:mu_dynamic", _NS).text
+            if prox.find("drake:mu_dynamic", _NS) is not None
+            and prox.find("drake:mu_dynamic", _NS).text
+            else 0.0
+        ) == pytest.approx(0.9)
 
 
 class TestAddGroundPlaneContact:
@@ -157,8 +177,18 @@ class TestAddGroundPlaneContact:
         ground = add_ground_plane_contact(model)
         collision = ground.find("collision")
         prox = collision.find("drake:proximity_properties", _NS)
-        assert float(prox.find("drake:mu_static", _NS).text if prox.find("drake:mu_static", _NS) is not None and prox.find("drake:mu_static", _NS).text else 0.0) == pytest.approx(0.8)
-        assert float(prox.find("drake:mu_dynamic", _NS).text if prox.find("drake:mu_dynamic", _NS) is not None and prox.find("drake:mu_dynamic", _NS).text else 0.0) == pytest.approx(0.6)
+        assert float(
+            prox.find("drake:mu_static", _NS).text
+            if prox.find("drake:mu_static", _NS) is not None
+            and prox.find("drake:mu_static", _NS).text
+            else 0.0
+        ) == pytest.approx(0.8)
+        assert float(
+            prox.find("drake:mu_dynamic", _NS).text
+            if prox.find("drake:mu_dynamic", _NS) is not None
+            and prox.find("drake:mu_dynamic", _NS).text
+            else 0.0
+        ) == pytest.approx(0.6)
 
     def test_welded_to_world(self, model: Any) -> None:
         add_ground_plane_contact(model)
@@ -256,7 +286,9 @@ class TestCollisionFilterGroup:
             name="knee_r",
             members=["thigh_r", "shank_r"],
         )
-        members = [m.text for m in group.findall("drake:member", _NS) if m.text is not None ]
+        members = [
+            m.text for m in group.findall("drake:member", _NS) if m.text is not None
+        ]
         assert "thigh_r" in members
         assert "shank_r" in members
 

--- a/tests/unit/shared/test_ground_contact.py
+++ b/tests/unit/shared/test_ground_contact.py
@@ -73,6 +73,7 @@ class TestAddContactGeometry:
         prox = collision.find("drake:proximity_properties", _NS)
         modulus = prox.find("drake:hydroelastic_modulus", _NS)
         assert modulus is not None
+        assert modulus is not None and modulus.text is not None
         assert float(modulus.text) == pytest.approx(1e7)
 
     def test_has_friction_coefficients(self, link: Any) -> None:
@@ -85,8 +86,8 @@ class TestAddContactGeometry:
             mu_dynamic=0.6,
         )
         prox = collision.find("drake:proximity_properties", _NS)
-        assert float(prox.find("drake:mu_static", _NS).text) == pytest.approx(0.8)
-        assert float(prox.find("drake:mu_dynamic", _NS).text) == pytest.approx(0.6)
+        assert float(prox.find("drake:mu_static", _NS).text if prox.find("drake:mu_static", _NS) is not None and prox.find("drake:mu_static", _NS).text else 0.0) == pytest.approx(0.8)
+        assert float(prox.find("drake:mu_dynamic", _NS).text if prox.find("drake:mu_dynamic", _NS) is not None and prox.find("drake:mu_dynamic", _NS).text else 0.0) == pytest.approx(0.6)
 
     def test_has_dissipation(self, link: Any) -> None:
         geom = make_box_geometry(0.26, 0.10, 0.02)
@@ -99,6 +100,7 @@ class TestAddContactGeometry:
         prox = collision.find("drake:proximity_properties", _NS)
         diss = prox.find("drake:hunt_crossley_dissipation", _NS)
         assert diss is not None
+        assert diss is not None and diss.text is not None
         assert float(diss.text) == pytest.approx(1.0)
 
     def test_has_pose(self, link: Any) -> None:
@@ -111,6 +113,7 @@ class TestAddContactGeometry:
         )
         pose = collision.find("pose")
         assert pose is not None
+        assert pose is not None and pose.text is not None
         assert "-0.050000" in pose.text
 
     def test_custom_friction(self, link: Any) -> None:
@@ -123,8 +126,8 @@ class TestAddContactGeometry:
             mu_dynamic=0.9,
         )
         prox = collision.find("drake:proximity_properties", _NS)
-        assert float(prox.find("drake:mu_static", _NS).text) == pytest.approx(1.2)
-        assert float(prox.find("drake:mu_dynamic", _NS).text) == pytest.approx(0.9)
+        assert float(prox.find("drake:mu_static", _NS).text if prox.find("drake:mu_static", _NS) is not None and prox.find("drake:mu_static", _NS).text else 0.0) == pytest.approx(1.2)
+        assert float(prox.find("drake:mu_dynamic", _NS).text if prox.find("drake:mu_dynamic", _NS) is not None and prox.find("drake:mu_dynamic", _NS).text else 0.0) == pytest.approx(0.9)
 
 
 class TestAddGroundPlaneContact:
@@ -154,8 +157,8 @@ class TestAddGroundPlaneContact:
         ground = add_ground_plane_contact(model)
         collision = ground.find("collision")
         prox = collision.find("drake:proximity_properties", _NS)
-        assert float(prox.find("drake:mu_static", _NS).text) == pytest.approx(0.8)
-        assert float(prox.find("drake:mu_dynamic", _NS).text) == pytest.approx(0.6)
+        assert float(prox.find("drake:mu_static", _NS).text if prox.find("drake:mu_static", _NS) is not None and prox.find("drake:mu_static", _NS).text else 0.0) == pytest.approx(0.8)
+        assert float(prox.find("drake:mu_dynamic", _NS).text if prox.find("drake:mu_dynamic", _NS) is not None and prox.find("drake:mu_dynamic", _NS).text else 0.0) == pytest.approx(0.6)
 
     def test_welded_to_world(self, model: Any) -> None:
         add_ground_plane_contact(model)
@@ -175,7 +178,9 @@ class TestAddGroundPlaneContact:
         collision = ground.find("collision")
         box = collision.find("geometry/box")
         assert box is not None
-        size = box.find("size").text
+        size_el = box.find("size")
+        assert size_el is not None and size_el.text is not None
+        size = size_el.text
         assert "100.000000" in size
 
 
@@ -208,7 +213,9 @@ class TestFootContactGeometry:
             assert contact is not None
             box = contact.find("geometry/box")
             assert box is not None
-            size = box.find("size").text
+            size_el = box.find("size")
+            assert size_el is not None and size_el.text is not None
+            size = size_el.text
             assert "0.260000" in size
             assert "0.100000" in size
             assert "0.020000" in size
@@ -249,7 +256,7 @@ class TestCollisionFilterGroup:
             name="knee_r",
             members=["thigh_r", "shank_r"],
         )
-        members = [m.text for m in group.findall("drake:member", _NS)]
+        members = [m.text for m in group.findall("drake:member", _NS) if m.text is not None ]
         assert "thigh_r" in members
         assert "shank_r" in members
 


### PR DESCRIPTION
Closes #90

## Summary
- Remove `|| echo "::warning::"` soft-fail from the **Security Audit** (`pip-audit`) step so any discovered vulnerability now fails the build
- Remove `2>&1 || echo "::warning::"` soft-fail from the **Bandit Security Scan** step so high/medium severity findings now fail the build
- Drop the unjustified `--ignore-vuln CVE-2026-4539` flag from `pip-audit` (no justification was documented; removing it ensures the advisory is evaluated on its merits)

## Test plan
- [ ] CI passes with security gates enabled (no current CVEs or bandit findings block the build)
- [ ] Introducing a known-vulnerable dep causes the Security Audit step to fail (not warn)
- [ ] Introducing a high-severity bandit finding causes the Bandit step to fail (not warn)