### PR TITLE
refactor: extract helpers to bring all functions under 50-line limit

### DIFF
--- a/src/drake_models/__main__.py
+++ b/src/drake_models/__main__.py
@@ -35,8 +35,8 @@ BUILDER_FUNCTIONS = {
 }
 
 
-def main(argv: list[str] | None = None) -> None:
-    """Generate a Drake SDF model for a barbell exercise."""
+def _build_arg_parser() -> argparse.ArgumentParser:
+    """Construct and return the CLI argument parser."""
     parser = argparse.ArgumentParser(
         prog="drake-models",
         description="Generate Drake SDF models for barbell exercises.",
@@ -77,16 +77,36 @@ def main(argv: list[str] | None = None) -> None:
         action="store_true",
         help="Enable verbose logging.",
     )
+    return parser
 
-    args = parser.parse_args(argv)
 
-    # DbC: validate numeric CLI arguments
+def _validate_args(parser: argparse.ArgumentParser, args: argparse.Namespace) -> None:
+    """Validate numeric CLI arguments; call parser.error on failure (DbC)."""
     if args.mass <= 0:
         parser.error(f"--mass must be positive, got {args.mass}")
     if args.height <= 0:
         parser.error(f"--height must be positive, got {args.height}")
     if args.plates < 0:
         parser.error(f"--plates must be non-negative, got {args.plates}")
+
+
+def _write_output(xml_str: str, output_path: str | None) -> None:
+    """Write *xml_str* to *output_path* or stdout when path is ``None``."""
+    if output_path:
+        with open(output_path, "w") as f:
+            f.write(xml_str)
+        logger.info("Wrote model to %s", output_path)
+    else:
+        stdout = sys.stdout
+        stdout.write(xml_str)
+        stdout.write("\n")
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Generate a Drake SDF model for a barbell exercise."""
+    parser = _build_arg_parser()
+    args = parser.parse_args(argv)
+    _validate_args(parser, args)
 
     logging.basicConfig(
         level=logging.DEBUG if args.verbose else logging.WARNING,
@@ -103,15 +123,7 @@ def main(argv: list[str] | None = None) -> None:
         height=args.height,
         plate_mass_per_side=args.plates,
     )
-
-    if args.output:
-        with open(args.output, "w") as f:
-            f.write(xml_str)
-        logger.info("Wrote model to %s", args.output)
-    else:
-        stdout = sys.stdout
-        stdout.write(xml_str)
-        stdout.write("\n")
+    _write_output(xml_str, args.output)
 
 
 if __name__ == "__main__":

--- a/src/drake_models/exercises/base.py
+++ b/src/drake_models/exercises/base.py
@@ -158,6 +158,47 @@ class ExerciseModelBuilder(ABC):
         )
 
     @staticmethod
+    def _bilateral_collision_pairs(side: str) -> list[tuple[str, list[str]]]:
+        """Return collision filter group definitions for one body side.
+
+        Args:
+            side: ``'l'`` or ``'r'``.
+
+        Returns:
+            List of ``(group_name, [member_links])`` tuples for the given side.
+        """
+        return [
+            (
+                f"hip_{side}",
+                [
+                    "pelvis",
+                    f"thigh_{side}",
+                    f"hip_{side}_virtual_1",
+                    f"hip_{side}_virtual_2",
+                ],
+            ),
+            (f"knee_{side}", [f"thigh_{side}", f"shank_{side}"]),
+            (
+                f"ankle_{side}",
+                [f"shank_{side}", f"foot_{side}", f"ankle_{side}_virtual_1"],
+            ),
+            (
+                f"shoulder_{side}",
+                [
+                    "torso",
+                    f"upper_arm_{side}",
+                    f"shoulder_{side}_virtual_1",
+                    f"shoulder_{side}_virtual_2",
+                ],
+            ),
+            (f"elbow_{side}", [f"upper_arm_{side}", f"forearm_{side}"]),
+            (
+                f"wrist_{side}",
+                [f"forearm_{side}", f"hand_{side}", f"wrist_{side}_virtual_1"],
+            ),
+        ]
+
+    @staticmethod
     def _add_collision_filters(model: ET.Element) -> None:
         """Add collision exclusion filters for adjacent body segments.
 
@@ -165,58 +206,12 @@ class ExerciseModelBuilder(ABC):
         detection between segments that are connected by joints. Without
         these filters, adjacent links would interpenetrate at joint limits.
         """
-        # Adjacent segment pairs that should not collide
-        adjacent_pairs = [
+        adjacent_pairs: list[tuple[str, list[str]]] = [
             ("torso_pelvis", ["pelvis", "torso"]),
             ("torso_head", ["torso", "head"]),
         ]
         for side in ("l", "r"):
-            adjacent_pairs.extend(
-                [
-                    (
-                        f"hip_{side}",
-                        [
-                            "pelvis",
-                            f"thigh_{side}",
-                            f"hip_{side}_virtual_1",
-                            f"hip_{side}_virtual_2",
-                        ],
-                    ),
-                    (
-                        f"knee_{side}",
-                        [f"thigh_{side}", f"shank_{side}"],
-                    ),
-                    (
-                        f"ankle_{side}",
-                        [
-                            f"shank_{side}",
-                            f"foot_{side}",
-                            f"ankle_{side}_virtual_1",
-                        ],
-                    ),
-                    (
-                        f"shoulder_{side}",
-                        [
-                            "torso",
-                            f"upper_arm_{side}",
-                            f"shoulder_{side}_virtual_1",
-                            f"shoulder_{side}_virtual_2",
-                        ],
-                    ),
-                    (
-                        f"elbow_{side}",
-                        [f"upper_arm_{side}", f"forearm_{side}"],
-                    ),
-                    (
-                        f"wrist_{side}",
-                        [
-                            f"forearm_{side}",
-                            f"hand_{side}",
-                            f"wrist_{side}_virtual_1",
-                        ],
-                    ),
-                ]
-            )
+            adjacent_pairs.extend(ExerciseModelBuilder._bilateral_collision_pairs(side))
         for group_name, members in adjacent_pairs:
             add_collision_filter_group(model, name=group_name, members=members)
         logger.debug("Added %d collision filter groups", len(adjacent_pairs))

--- a/src/drake_models/exercises/sit_to_stand/sit_to_stand_model.py
+++ b/src/drake_models/exercises/sit_to_stand/sit_to_stand_model.py
@@ -63,20 +63,24 @@ class SitToStandModelBuilder(ExerciseModelBuilder):
         """Return the canonical exercise name for the sit-to-stand model."""
         return "sit_to_stand"
 
-    def _add_chair_body(self, model: ET.Element) -> ET.Element:
-        """Add the chair seat link and weld it to the world.
+    @staticmethod
+    def _make_chair_seat_link(model: ET.Element) -> ET.Element:
+        """Create the chair seat link and return it (no joints added).
 
-        The chair seat is a box welded to the world frame so that its
-        top surface sits at CHAIR_SEAT_HEIGHT meters above ground.
+        Returns the created ``<link>`` element for further use.
         """
-        seat_z_center = CHAIR_SEAT_HEIGHT - CHAIR_SEAT_THICKNESS / 2.0
         inertia = rectangular_prism_inertia(
             CHAIR_MASS,
             CHAIR_SEAT_DEPTH,
             CHAIR_SEAT_WIDTH,
             CHAIR_SEAT_THICKNESS,
         )
-        chair_link = add_link(
+        seat_geom = make_box_geometry(
+            CHAIR_SEAT_DEPTH,
+            CHAIR_SEAT_WIDTH,
+            CHAIR_SEAT_THICKNESS,
+        )
+        return add_link(
             model,
             name="chair_seat",
             mass=CHAIR_MASS,
@@ -84,25 +88,17 @@ class SitToStandModelBuilder(ExerciseModelBuilder):
             inertia_xx=inertia[0],
             inertia_yy=inertia[1],
             inertia_zz=inertia[2],
-            visual_geometry=make_box_geometry(
-                CHAIR_SEAT_DEPTH,
-                CHAIR_SEAT_WIDTH,
-                CHAIR_SEAT_THICKNESS,
-            ),
+            visual_geometry=seat_geom,
             collision_geometry=make_box_geometry(
                 CHAIR_SEAT_DEPTH,
                 CHAIR_SEAT_WIDTH,
                 CHAIR_SEAT_THICKNESS,
             ),
         )
-        add_fixed_joint(
-            model,
-            name="chair_to_world",
-            parent="world",
-            child="chair_seat",
-            pose=(0, 0, seat_z_center, 0, 0, 0),
-        )
 
+    @staticmethod
+    def _add_chair_contact(chair_link: ET.Element) -> None:
+        """Attach hydroelastic contact geometry to the chair seat link."""
         add_contact_geometry(
             chair_link,
             name="chair_seat_contact",
@@ -115,6 +111,22 @@ class SitToStandModelBuilder(ExerciseModelBuilder):
             hydroelastic_modulus=1e8,
         )
 
+    def _add_chair_body(self, model: ET.Element) -> ET.Element:
+        """Add the chair seat link and weld it to the world.
+
+        The chair seat is a box welded to the world frame so that its
+        top surface sits at CHAIR_SEAT_HEIGHT meters above ground.
+        """
+        seat_z_center = CHAIR_SEAT_HEIGHT - CHAIR_SEAT_THICKNESS / 2.0
+        chair_link = self._make_chair_seat_link(model)
+        add_fixed_joint(
+            model,
+            name="chair_to_world",
+            parent="world",
+            child="chair_seat",
+            pose=(0, 0, seat_z_center, 0, 0, 0),
+        )
+        self._add_chair_contact(chair_link)
         logger.debug("Added chair seat welded to world at z=%.3f m", seat_z_center)
         return chair_link
 

--- a/src/drake_models/optimization/inverse_kinematics.py
+++ b/src/drake_models/optimization/inverse_kinematics.py
@@ -21,6 +21,13 @@ from drake_models.optimization.exercise_objectives import (
 logger = logging.getLogger(__name__)
 
 
+def _pydrake_available() -> bool:
+    """Return ``True`` if pydrake is installed and importable."""
+    import importlib.util
+
+    return importlib.util.find_spec("pydrake") is not None
+
+
 def solve_ik_keyframes(
     sdf_string: str,
     exercise_name: str,
@@ -55,23 +62,18 @@ def solve_ik_keyframes(
 
     objective = get_objective(exercise_name)
 
-    try:
-        import importlib.util
-
-        if importlib.util.find_spec("pydrake") is None:
-            raise ImportError("pydrake not installed")
-
+    if _pydrake_available():
         logger.info(
             "Drake available — using IK solver for %s keyframes",
             exercise_name,
         )
         return _solve_ik_with_drake(sdf_string, objective, n_frames)
-    except ImportError:
-        logger.info(
-            "Drake not available — using phase interpolation for %s keyframes",
-            exercise_name,
-        )
-        return _interpolate_phases(objective, n_frames)
+
+    logger.info(
+        "Drake not available — using phase interpolation for %s keyframes",
+        exercise_name,
+    )
+    return _interpolate_phases(objective, n_frames)
 
 
 def _interpolate_phases(
@@ -116,6 +118,52 @@ def _interpolate_phases(
     return keyframes
 
 
+def _build_ik_plant(sdf_string: str) -> object:
+    """Load *sdf_string* into a finalised Drake MultibodyPlant for IK.
+
+    Returns the plant.  Callers must have pydrake available.
+    """
+    from pydrake.all import AddMultibodyPlantSceneGraph, DiagramBuilder, Parser
+
+    builder = DiagramBuilder()
+    plant, _scene_graph = AddMultibodyPlantSceneGraph(builder, time_step=0.0)
+    parser = Parser(plant)
+    parser.AddModelsFromString(sdf_string, "sdf")
+    plant.Finalize()
+    return plant
+
+
+def _refine_keyframe(
+    plant: object,
+    initial_guess: np.ndarray,
+    n_q: int,
+    n_joints: int,
+    frame_index: int,
+) -> np.ndarray:
+    """Refine one keyframe via Drake's InverseKinematics solver.
+
+    Returns the refined joint angles (length *n_joints*).  Falls back to
+    *initial_guess* if the IK solve fails.
+    """
+    from pydrake.all import InverseKinematics, Solve
+
+    ik = InverseKinematics(plant)  # type: ignore[arg-type]
+    q_vars = ik.q()
+    prog = ik.get_mutable_prog()
+
+    q_init = np.zeros(n_q)
+    for j in range(min(n_joints, n_q)):
+        q_init[j] = initial_guess[j]
+    prog.SetInitialGuess(q_vars, q_init)
+
+    result = Solve(prog)
+    if result.is_success():
+        return result.GetSolution(q_vars)[:n_joints]
+
+    logger.warning("IK failed for keyframe %d, using interpolation", frame_index)
+    return initial_guess
+
+
 def _solve_ik_with_drake(
     sdf_string: str,
     objective: ExerciseObjective,
@@ -127,47 +175,16 @@ def _solve_ik_with_drake(
     Drake's IK solver to ensure kinematic feasibility within the
     multibody model's joint limits and constraints.
     """
-    from pydrake.all import (
-        AddMultibodyPlantSceneGraph,
-        DiagramBuilder,
-        InverseKinematics,
-        Parser,
-        Solve,
-    )
-
-    # Build plant
-    builder = DiagramBuilder()
-    plant, scene_graph = AddMultibodyPlantSceneGraph(builder, time_step=0.0)
-    parser = Parser(plant)
-    parser.AddModelsFromString(sdf_string, "sdf")
-    plant.Finalize()
-
-    # Get initial interpolation
+    plant = _build_ik_plant(sdf_string)
     initial_keyframes = _interpolate_phases(objective, n_frames)
-    n_q = plant.num_positions()
+    n_q = plant.num_positions()  # type: ignore[attr-defined]
     n_joints = initial_keyframes.shape[1]
 
     refined = np.zeros((n_frames, n_joints))
-
     for i in range(n_frames):
-        ik = InverseKinematics(plant)
-        q_vars = ik.q()
-
-        # Set initial guess from interpolation
-        prog = ik.get_mutable_prog()
-        q_init = np.zeros(n_q)
-        for j in range(min(n_joints, n_q)):
-            q_init[j] = initial_keyframes[i, j]
-        prog.SetInitialGuess(q_vars, q_init)
-
-        result = Solve(prog)
-        if result.is_success():
-            q_sol = result.GetSolution(q_vars)
-            refined[i, :] = q_sol[:n_joints]
-        else:
-            # Fall back to interpolated values
-            refined[i, :] = initial_keyframes[i, :]
-            logger.warning("IK failed for keyframe %d, using interpolation", i)
+        refined[i, :] = _refine_keyframe(
+            plant, initial_keyframes[i, :], n_q, n_joints, i
+        )
 
     logger.info(
         "Generated %d IK-refined keyframes for %s",

--- a/src/drake_models/optimization/trajectory_optimizer.py
+++ b/src/drake_models/optimization/trajectory_optimizer.py
@@ -170,68 +170,107 @@ def compute_terminal_cost(
 # ---------------------------------------------------------------------------
 
 
+def _build_phase_arrays(
+    objective: ExerciseObjective,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Extract phase time fractions and clean joint-angle arrays from *objective*.
+
+    Returns:
+        ``(phase_times, phase_angles_clean)`` where NaN values are replaced
+        with 0.0 for safe interpolation.
+    """
+    phase_times = np.array([p.time_fraction for p in objective.phases])
+    phase_angles = objective.phase_angles_array()
+    phase_angles_clean = np.where(np.isnan(phase_angles), 0.0, phase_angles)
+    return phase_times, phase_angles_clean
+
+
+def _compute_interpolated_cost(
+    positions: np.ndarray,
+    torques: np.ndarray,
+    terminal_target: np.ndarray,
+    config: TrajectoryConfig,
+) -> float:
+    """Compute the nominal cost for an interpolated (Drake-free) trajectory.
+
+    Combines quadratic control cost with terminal tracking cost.
+    """
+    total = compute_control_cost(torques, config.control_weight)
+    total += compute_terminal_cost(
+        positions[-1], terminal_target, config.terminal_weight
+    )
+    return total
+
+
+def _interpolate_joint_positions(
+    phase_times: np.ndarray,
+    phase_angles_clean: np.ndarray,
+    time_fracs: np.ndarray,
+    n_joints: int,
+) -> np.ndarray:
+    """Linearly interpolate joint angles across *time_fracs* from phase keyframes.
+
+    Returns an ``(n_steps, n_joints)`` array of interpolated positions.
+    """
+    n_steps = len(time_fracs)
+    positions = np.zeros((n_steps, n_joints))
+    for j in range(n_joints):
+        positions[:, j] = np.interp(time_fracs, phase_times, phase_angles_clean[:, j])
+    return positions
+
+
+def _finite_diff_velocities(positions: np.ndarray, dt: float) -> np.ndarray:
+    """Compute finite-difference joint velocities from *positions*.
+
+    Returns a zero-padded array of the same shape (first row is zero).
+    """
+    velocities = np.zeros_like(positions)
+    if len(positions) > 1:
+        velocities[1:] = np.diff(positions, axis=0) / dt
+    return velocities
+
+
 def interpolate_trajectory(
     objective: ExerciseObjective,
     config: TrajectoryConfig,
 ) -> TrajectoryResult:
     """Generate a smooth trajectory by interpolating between exercise phases.
 
-    This is a simplified fallback that does not require Drake. It creates
-    a cubic-spline-like interpolation between the phase keyframes.
+    Drake-free fallback. Linearly interpolates phase keyframes and returns
+    zero torques with a nominal cost.
 
     Args:
         objective: Exercise objective containing phase targets and joint names.
         config: Trajectory configuration with timestep and weight parameters.
 
     Returns:
-        TrajectoryResult with interpolated positions, zero-initialized
-        velocities and torques, and a nominal cost.
+        TrajectoryResult with interpolated positions and a nominal cost.
 
     Raises:
-        ValueError: If objective has fewer than 2 phases or config is invalid.
+        ValueError: If objective has no phases.
     """
     if not objective.phases:
         raise ValueError("objective must have at least one phase")
-    joint_names = objective.joint_names()
-    n_joints = len(joint_names)
+    n_joints = len(objective.joint_names())
     n_steps = config.n_timesteps
     time = np.linspace(0.0, config.total_time, n_steps)
     time_fracs = np.linspace(0.0, 1.0, n_steps)
 
-    # Build keyframe arrays
-    phase_times = np.array([p.time_fraction for p in objective.phases])
-    phase_angles = objective.phase_angles_array()
-
-    # Replace NaN with 0.0 for interpolation
-    phase_angles_clean = np.where(np.isnan(phase_angles), 0.0, phase_angles)
-
-    # Linear interpolation per joint
-    positions = np.zeros((n_steps, n_joints))
-    for j in range(n_joints):
-        positions[:, j] = np.interp(time_fracs, phase_times, phase_angles_clean[:, j])
-
-    # Finite-difference velocities
-    velocities = np.zeros_like(positions)
-    if n_steps > 1:
-        velocities[1:] = np.diff(positions, axis=0) / config.dt
-
-    # Zero torques (no dynamics model)
-    torques = np.zeros_like(positions)
-
-    # Compute nominal cost
-    total_cost = compute_control_cost(torques, config.control_weight)
-    terminal_target = phase_angles_clean[-1]
-    total_cost += compute_terminal_cost(
-        positions[-1], terminal_target, config.terminal_weight
+    phase_times, phase_angles_clean = _build_phase_arrays(objective)
+    positions = _interpolate_joint_positions(
+        phase_times, phase_angles_clean, time_fracs, n_joints
     )
-
+    velocities = _finite_diff_velocities(positions, config.dt)
+    torques = np.zeros_like(positions)
+    total_cost = _compute_interpolated_cost(
+        positions, torques, phase_angles_clean[-1], config
+    )
     logger.info(
         "Interpolated trajectory: %d steps, %d joints, cost=%.4f",
         n_steps,
         n_joints,
         total_cost,
     )
-
     return TrajectoryResult(
         joint_positions=positions,
         joint_velocities=velocities,
@@ -248,6 +287,24 @@ def interpolate_trajectory(
 # ---------------------------------------------------------------------------
 
 
+def _try_drake_solve(
+    sdf_string: str,
+    objective: ExerciseObjective,
+    config: TrajectoryConfig,
+) -> TrajectoryResult | None:
+    """Attempt to solve with Drake; return ``None`` if pydrake is unavailable.
+
+    Returns:
+        A ``TrajectoryResult`` from Drake's MathematicalProgram, or ``None``
+        when pydrake is not installed so the caller can fall back.
+    """
+    import importlib.util
+
+    if importlib.util.find_spec("pydrake") is None:
+        return None
+    return _solve_with_drake(sdf_string, objective, config)
+
+
 def create_trajectory_optimization(
     sdf_string: str,
     exercise_name: str,
@@ -255,23 +312,13 @@ def create_trajectory_optimization(
 ) -> TrajectoryResult:
     """Create and solve a trajectory optimization for the given exercise.
 
-    Uses Drake's mathematical programming when available to solve:
-
-        min  sum_k [ control_weight * ||u_k||^2
-                    + state_weight * ||x_k - x_target_k||^2 ]
-             + terminal_weight * ||x_T - x_final||^2
-
-        s.t. dynamics constraints (MultibodyPlant)
-             joint limit constraints
-             contact constraints (foot on ground)
-             balance constraint (CoM over BoS)
-
-    When Drake is not installed, falls back to phase interpolation.
+    Uses Drake's MathematicalProgram when pydrake is installed; otherwise
+    falls back to phase interpolation via ``interpolate_trajectory``.
 
     Args:
-        sdf_string: Complete SDF model XML string.
+        sdf_string: Complete SDF model XML string (non-empty).
         exercise_name: Name matching a registered ExerciseObjective.
-        config: Solver configuration. Uses defaults if ``None``.
+        config: Solver configuration; uses defaults if ``None``.
 
     Returns:
         TrajectoryResult with optimized (or interpolated) trajectory.
@@ -286,24 +333,85 @@ def create_trajectory_optimization(
     config = config or TrajectoryConfig()
     objective = get_objective(exercise_name)
 
-    # Try Drake-based optimization
-    try:
-        import importlib.util
-
-        if importlib.util.find_spec("pydrake") is None:
-            raise ImportError("pydrake not installed")
-
+    drake_result = _try_drake_solve(sdf_string, objective, config)
+    if drake_result is not None:
         logger.info(
-            "Drake available — using mathematical programming for %s",
-            exercise_name,
+            "Drake available — using mathematical programming for %s", exercise_name
         )
-        return _solve_with_drake(sdf_string, objective, config)
-    except ImportError:
-        logger.info(
-            "Drake not available — falling back to phase interpolation for %s",
-            exercise_name,
+        return drake_result
+
+    logger.info(
+        "Drake not available — falling back to phase interpolation for %s",
+        exercise_name,
+    )
+    return interpolate_trajectory(objective, config)
+
+
+def _build_drake_plant(sdf_string: str, dt: float) -> object:
+    """Load *sdf_string* into a finalised Drake MultibodyPlant.
+
+    Returns the finalized plant object.  Callers must have pydrake available.
+    """
+    from pydrake.all import (
+        AddMultibodyPlantSceneGraph,
+        DiagramBuilder,
+        Parser,
+    )
+
+    builder = DiagramBuilder()
+    plant, _scene_graph = AddMultibodyPlantSceneGraph(builder, time_step=dt)
+    parser = Parser(plant)
+    parser.AddModelsFromString(sdf_string, "sdf")
+    plant.Finalize()
+    return plant
+
+
+def _add_control_costs(prog: object, u: object, n_steps: int, weight: float) -> None:
+    """Add per-timestep quadratic control costs to *prog*.
+
+    Minimises ``weight * ||u_k||^2`` at each knot point.
+    """
+    import numpy as np
+    from pydrake.all import MathematicalProgram  # noqa: F401 (type check guard)
+
+    n_u = u.shape[1]  # type: ignore[attr-defined]
+    for k in range(n_steps):
+        prog.AddQuadraticCost(  # type: ignore[attr-defined]
+            weight * np.eye(n_u),
+            np.zeros(n_u),
+            u[k],  # type: ignore[index]
         )
-        return interpolate_trajectory(objective, config)
+
+
+def _add_phase_tracking_costs(
+    prog: object,
+    q: object,
+    objective: ExerciseObjective,
+    n_q: int,
+    n_steps: int,
+    state_weight: float,
+    terminal_weight: float,
+) -> None:
+    """Add phase-tracking quadratic costs to *prog*.
+
+    Each exercise phase maps to a knot-point index via its time fraction.
+    The final phase uses *terminal_weight*; all others use *state_weight*.
+    """
+    joint_names = objective.joint_names()
+    for phase in objective.phases:
+        k = int(phase.time_fraction * (n_steps - 1))
+        target = np.zeros(n_q)
+        for jname, angle in phase.joint_angles.items():
+            if jname in joint_names:
+                idx = joint_names.index(jname)
+                if idx < n_q:
+                    target[idx] = angle
+        w = terminal_weight if phase is objective.phases[-1] else state_weight
+        prog.AddQuadraticCost(  # type: ignore[attr-defined]
+            w * np.eye(n_q),
+            -w * target,
+            q[k],  # type: ignore[index]
+        )
 
 
 def _solve_with_drake(
@@ -316,61 +424,31 @@ def _solve_with_drake(
     This is the full-fidelity path when pydrake is installed. It sets up
     a direct transcription with MultibodyPlant dynamics constraints.
     """
-    from pydrake.all import (
-        AddMultibodyPlantSceneGraph,
-        DiagramBuilder,
-        MathematicalProgram,
-        Parser,
-        Solve,
-    )
+    from pydrake.all import MathematicalProgram, Solve
 
-    # Build plant
-    builder = DiagramBuilder()
-    plant, scene_graph = AddMultibodyPlantSceneGraph(builder, time_step=config.dt)
-    parser = Parser(plant)
-    parser.AddModelsFromString(sdf_string, "sdf")
-    plant.Finalize()
-
-    n_q = plant.num_positions()
-    n_v = plant.num_velocities()
-    n_u = plant.num_actuators()
+    plant = _build_drake_plant(sdf_string, config.dt)
+    n_q = plant.num_positions()  # type: ignore[attr-defined]
+    n_v = plant.num_velocities()  # type: ignore[attr-defined]
+    n_u = plant.num_actuators()  # type: ignore[attr-defined]
     n_steps = config.n_timesteps
 
-    # Direct transcription
     prog = MathematicalProgram()
-
-    # Decision variables
     q = prog.NewContinuousVariables(n_steps, n_q, "q")
     v = prog.NewContinuousVariables(n_steps, n_v, "v")
     u = prog.NewContinuousVariables(n_steps, n_u, "u")
 
-    # Control cost
-    for k in range(n_steps):
-        prog.AddQuadraticCost(
-            config.control_weight * np.eye(n_u),
-            np.zeros(n_u),
-            u[k],
-        )
-
-    # Phase tracking costs
-    joint_names = objective.joint_names()
-    for phase in objective.phases:
-        k = int(phase.time_fraction * (n_steps - 1))
-        target = np.zeros(n_q)
-        for jname, angle in phase.joint_angles.items():
-            if jname in joint_names:
-                idx = joint_names.index(jname)
-                if idx < n_q:
-                    target[idx] = angle
-        w = (
-            config.terminal_weight
-            if phase is objective.phases[-1]
-            else config.state_weight
-        )
-        prog.AddQuadraticCost(w * np.eye(n_q), -w * target, q[k])
+    _add_control_costs(prog, u, n_steps, config.control_weight)
+    _add_phase_tracking_costs(
+        prog,
+        q,
+        objective,
+        n_q,
+        n_steps,
+        config.state_weight,
+        config.terminal_weight,
+    )
 
     result = Solve(prog)
-
     positions = result.GetSolution(q)
     velocities = result.GetSolution(v)
     torques = result.GetSolution(u)

--- a/src/drake_models/shared/barbell/barbell_model.py
+++ b/src/drake_models/shared/barbell/barbell_model.py
@@ -158,38 +158,19 @@ def _hollow_cylinder_inertia_y_axis(
     return (ixx_t, izz_axial, iyy_t)
 
 
-def create_barbell_links(
-    model: ET.Element,
+def _compute_sleeve_inertia(
     spec: BarbellSpec,
-    *,
-    prefix: str = "barbell",
-) -> dict[str, ET.Element]:
-    """Add barbell links and fixed joints to an SDF model element.
+) -> tuple[tuple[float, float, float], float]:
+    """Compute combined sleeve+plate inertia and total sleeve mass.
 
-    Returns dict of created link elements keyed by name.
-
-    The barbell shaft center is at the local origin. Sleeves extend
-    symmetrically along the Y-axis (left = -Y, right = +Y) in the
-    Drake Z-up convention.  All cylinder geometries are pre-rotated
-    with roll=π/2 so their long axes align with Y.
+    Returns:
+        ``(sleeve_inertia, sleeve_total_mass)`` where *sleeve_inertia* is a
+        ``(Ixx, Iyy, Izz)`` tuple for a Y-aligned cylinder and
+        *sleeve_total_mass* = bare sleeve mass + plate mass per side.
     """
-    logger.info(
-        "Building barbell: total_mass=%.1f kg, length=%.2f m",
-        spec.total_mass,
-        spec.total_length,
-    )
-
-    # Inertia for Y-aligned cylinders (axial moment is about Y)
-    shaft_inertia = _cylinder_inertia_y_axis(
-        spec.shaft_mass, spec.shaft_radius, spec.shaft_length
-    )
-
-    # Compute bare sleeve inertia
     sleeve_inertia = _cylinder_inertia_y_axis(
         spec.sleeve_mass, spec.sleeve_radius, spec.sleeve_length
     )
-
-    # Add plate inertia using correct plate radius (0.225 m), not sleeve radius
     if spec.plate_mass_per_side > 0:
         plate_thickness = max(0.01, spec.plate_mass_per_side * 0.002)
         plate_inertia = _hollow_cylinder_inertia_y_axis(
@@ -203,62 +184,65 @@ def create_barbell_links(
             sleeve_inertia[1] + plate_inertia[1],
             sleeve_inertia[2] + plate_inertia[2],
         )
-
     sleeve_total_mass = spec.sleeve_mass + spec.plate_mass_per_side
+    return sleeve_inertia, sleeve_total_mass
 
-    shaft_name = f"{prefix}_shaft"
-    left_name = f"{prefix}_left_sleeve"
-    right_name = f"{prefix}_right_sleeve"
 
-    shaft_link = add_link(
+def _make_sleeve_link(
+    model: ET.Element,
+    name: str,
+    mass: float,
+    inertia: tuple[float, float, float],
+    radius: float,
+    length: float,
+) -> ET.Element:
+    """Append a Y-aligned cylinder sleeve link to *model* and return it."""
+    geom = make_cylinder_geometry_y(radius, length)
+    return add_link(
         model,
-        name=shaft_name,
+        name=name,
+        mass=mass,
+        mass_center=(0, 0, 0),
+        inertia_xx=inertia[0],
+        inertia_yy=inertia[1],
+        inertia_zz=inertia[2],
+        visual_geometry=geom,
+        collision_geometry=make_cylinder_geometry_y(radius, length),
+    )
+
+
+def _make_shaft_link(
+    model: ET.Element,
+    name: str,
+    spec: BarbellSpec,
+    inertia: tuple[float, float, float],
+) -> ET.Element:
+    """Append the barbell shaft link to *model* and return it."""
+    return add_link(
+        model,
+        name=name,
         mass=spec.shaft_mass,
         mass_center=(0, 0, 0),
-        inertia_xx=shaft_inertia[0],
-        inertia_yy=shaft_inertia[1],
-        inertia_zz=shaft_inertia[2],
+        inertia_xx=inertia[0],
+        inertia_yy=inertia[1],
+        inertia_zz=inertia[2],
         visual_geometry=make_cylinder_geometry_y(spec.shaft_radius, spec.shaft_length),
         collision_geometry=make_cylinder_geometry_y(
             spec.shaft_radius, spec.shaft_length
         ),
     )
 
-    left_link = add_link(
-        model,
-        name=left_name,
-        mass=sleeve_total_mass,
-        mass_center=(0, 0, 0),
-        inertia_xx=sleeve_inertia[0],
-        inertia_yy=sleeve_inertia[1],
-        inertia_zz=sleeve_inertia[2],
-        visual_geometry=make_cylinder_geometry_y(
-            spec.sleeve_radius, spec.sleeve_length
-        ),
-        collision_geometry=make_cylinder_geometry_y(
-            spec.sleeve_radius, spec.sleeve_length
-        ),
-    )
 
-    right_link = add_link(
-        model,
-        name=right_name,
-        mass=sleeve_total_mass,
-        mass_center=(0, 0, 0),
-        inertia_xx=sleeve_inertia[0],
-        inertia_yy=sleeve_inertia[1],
-        inertia_zz=sleeve_inertia[2],
-        visual_geometry=make_cylinder_geometry_y(
-            spec.sleeve_radius, spec.sleeve_length
-        ),
-        collision_geometry=make_cylinder_geometry_y(
-            spec.sleeve_radius, spec.sleeve_length
-        ),
-    )
-
-    half_shaft = spec.shaft_length / 2.0
-    half_sleeve = spec.sleeve_length / 2.0
-
+def _weld_sleeves(
+    model: ET.Element,
+    prefix: str,
+    shaft_name: str,
+    left_name: str,
+    right_name: str,
+    half_shaft: float,
+    half_sleeve: float,
+) -> None:
+    """Weld the left and right sleeves to the shaft at symmetric Y offsets."""
     add_fixed_joint(
         model,
         name=f"{prefix}_left_weld",
@@ -266,7 +250,6 @@ def create_barbell_links(
         child=left_name,
         pose=(0, -half_shaft - half_sleeve, 0, 0, 0, 0),
     )
-
     add_fixed_joint(
         model,
         name=f"{prefix}_right_weld",
@@ -275,8 +258,56 @@ def create_barbell_links(
         pose=(0, half_shaft + half_sleeve, 0, 0, 0, 0),
     )
 
-    return {
-        shaft_name: shaft_link,
-        left_name: left_link,
-        right_name: right_link,
-    }
+
+def create_barbell_links(
+    model: ET.Element,
+    spec: BarbellSpec,
+    *,
+    prefix: str = "barbell",
+) -> dict[str, ET.Element]:
+    """Add barbell links and fixed joints to an SDF model element.
+
+    Returns dict of created link elements keyed by name.  The shaft centre is
+    at the local origin; sleeves extend along ±Y (Drake Z-up convention).
+    """
+    logger.info(
+        "Building barbell: total_mass=%.1f kg, length=%.2f m",
+        spec.total_mass,
+        spec.total_length,
+    )
+    shaft_inertia = _cylinder_inertia_y_axis(
+        spec.shaft_mass, spec.shaft_radius, spec.shaft_length
+    )
+    sleeve_inertia, sleeve_total_mass = _compute_sleeve_inertia(spec)
+
+    shaft_name = f"{prefix}_shaft"
+    left_name = f"{prefix}_left_sleeve"
+    right_name = f"{prefix}_right_sleeve"
+
+    shaft_link = _make_shaft_link(model, shaft_name, spec, shaft_inertia)
+    left_link = _make_sleeve_link(
+        model,
+        left_name,
+        sleeve_total_mass,
+        sleeve_inertia,
+        spec.sleeve_radius,
+        spec.sleeve_length,
+    )
+    right_link = _make_sleeve_link(
+        model,
+        right_name,
+        sleeve_total_mass,
+        sleeve_inertia,
+        spec.sleeve_radius,
+        spec.sleeve_length,
+    )
+    _weld_sleeves(
+        model,
+        prefix,
+        shaft_name,
+        left_name,
+        right_name,
+        spec.shaft_length / 2.0,
+        spec.sleeve_length / 2.0,
+    )
+    return {shaft_name: shaft_link, left_name: left_link, right_name: right_link}

--- a/src/drake_models/shared/body/body_model.py
+++ b/src/drake_models/shared/body/body_model.py
@@ -160,6 +160,33 @@ def _seg(spec: BodyModelSpec, name: str) -> tuple[float, float, float]:
     return mass, length, radius
 
 
+def _make_cylinder_segment_link(
+    model: ET.Element,
+    *,
+    name: str,
+    mass: float,
+    length: float,
+    radius: float,
+) -> ET.Element:
+    """Append a Z-aligned cylinder segment link to *model* and return it.
+
+    Mass centre is placed at the distal end (0, 0, -length/2) following
+    the Drake Z-up convention where limbs extend downward from their joint.
+    """
+    inertia = cylinder_inertia(mass, radius, length)
+    return add_link(
+        model,
+        name=name,
+        mass=mass,
+        mass_center=(0, 0, -length / 2.0),
+        inertia_xx=inertia[0],
+        inertia_yy=inertia[1],
+        inertia_zz=inertia[2],
+        visual_geometry=make_cylinder_geometry(radius, length),
+        collision_geometry=make_cylinder_geometry(radius, length),
+    )
+
+
 def _add_bilateral_limb(
     model: ET.Element,
     spec: BodyModelSpec,
@@ -181,23 +208,13 @@ def _add_bilateral_limb(
     Returns dict of created link elements keyed by name.
     """
     mass, length, radius = _seg(spec, seg_name)
-    inertia = cylinder_inertia(mass, radius, length)
     created: dict[str, ET.Element] = {}
 
     for side, sign in [("l", -1.0), ("r", 1.0)]:
         link_name = f"{seg_name}_{side}"
         parent_link = f"{parent_name}_{side}" if "_" in parent_name else parent_name
-
-        created[link_name] = add_link(
-            model,
-            name=link_name,
-            mass=mass,
-            mass_center=(0, 0, -length / 2.0),
-            inertia_xx=inertia[0],
-            inertia_yy=inertia[1],
-            inertia_zz=inertia[2],
-            visual_geometry=make_cylinder_geometry(radius, length),
-            collision_geometry=make_cylinder_geometry(radius, length),
+        created[link_name] = _make_cylinder_segment_link(
+            model, name=link_name, mass=mass, length=length, radius=radius
         )
         add_revolute_joint(
             model,
@@ -211,6 +228,85 @@ def _add_bilateral_limb(
         )
 
     return created
+
+
+def _add_flex_joint(
+    model: ET.Element,
+    name: str,
+    parent: str,
+    child: str,
+    pose: tuple[float, float, float, float, float, float],
+    limits: tuple[float, float],
+) -> None:
+    """Add a flexion revolute joint (X-axis) at the given pose."""
+    add_revolute_joint(
+        model,
+        name=name,
+        parent=parent,
+        child=child,
+        axis_xyz=(1, 0, 0),
+        pose=pose,
+        lower_limit=limits[0],
+        upper_limit=limits[1],
+    )
+
+
+def _add_3dof_joint_chain(
+    model: ET.Element,
+    *,
+    coord_prefix: str,
+    side: str,
+    sign: float,
+    parent_link: str,
+    link_name: str,
+    parent_offset_z: float,
+    parent_lateral_y: float,
+    flex_limits: tuple[float, float],
+    adduct_limits: tuple[float, float],
+    rotate_limits: tuple[float, float],
+    adduct_label: str,
+    rotate_label: str,
+) -> tuple[str, str]:
+    """Wire virtual links and joints for one side of a 3-DOF compound joint.
+
+    Creates two virtual links and three revolute joints:
+      parent -> flex (X) -> v1 -> adduct (Z) -> v2 -> rotate (Y) -> child.
+
+    Returns ``(v1_name, v2_name)`` of the two newly-created virtual links.
+    """
+    v1_name = f"{coord_prefix}_{side}_virtual_1"
+    v2_name = f"{coord_prefix}_{side}_virtual_2"
+    add_virtual_link(model, name=v1_name)
+    add_virtual_link(model, name=v2_name)
+    _add_flex_joint(
+        model,
+        f"{coord_prefix}_{side}_flex",
+        parent_link,
+        v1_name,
+        (0, sign * parent_lateral_y, parent_offset_z, 0, 0, 0),
+        flex_limits,
+    )
+    add_revolute_joint(
+        model,
+        name=f"{coord_prefix}_{side}_{adduct_label}",
+        parent=v1_name,
+        child=v2_name,
+        axis_xyz=(0, 0, 1),
+        pose=(0, 0, 0, 0, 0, 0),
+        lower_limit=adduct_limits[0],
+        upper_limit=adduct_limits[1],
+    )
+    add_revolute_joint(
+        model,
+        name=f"{coord_prefix}_{side}_{rotate_label}",
+        parent=v2_name,
+        child=link_name,
+        axis_xyz=(0, 1, 0),
+        pose=(0, 0, 0, 0, 0, 0),
+        lower_limit=rotate_limits[0],
+        upper_limit=rotate_limits[1],
+    )
+    return v1_name, v2_name
 
 
 def _add_compound_3dof_bilateral(
@@ -235,67 +331,78 @@ def _add_compound_3dof_bilateral(
       -> virtual_2 -> {prefix}_rotate joint -> child segment link
     """
     mass, length, radius = _seg(spec, seg_name)
-    inertia = cylinder_inertia(mass, radius, length)
     created: dict[str, ET.Element] = {}
 
     for side, sign in [("l", -1.0), ("r", 1.0)]:
         link_name = f"{seg_name}_{side}"
         parent_link = f"{parent_name}_{side}" if "_" in parent_name else parent_name
-        v1_name = f"{coord_prefix}_{side}_virtual_1"
-        v2_name = f"{coord_prefix}_{side}_virtual_2"
-
-        # Virtual links
-        created[v1_name] = add_virtual_link(model, name=v1_name)
-        created[v2_name] = add_virtual_link(model, name=v2_name)
-
-        # Real segment link
-        created[link_name] = add_link(
-            model,
-            name=link_name,
-            mass=mass,
-            mass_center=(0, 0, -length / 2.0),
-            inertia_xx=inertia[0],
-            inertia_yy=inertia[1],
-            inertia_zz=inertia[2],
-            visual_geometry=make_cylinder_geometry(radius, length),
-            collision_geometry=make_cylinder_geometry(radius, length),
+        created[link_name] = _make_cylinder_segment_link(
+            model, name=link_name, mass=mass, length=length, radius=radius
         )
-
-        # Joint 1: flexion (X-axis) -- parent to virtual_1
-        add_revolute_joint(
+        v1, v2 = _add_3dof_joint_chain(
             model,
-            name=f"{coord_prefix}_{side}_flex",
-            parent=parent_link,
-            child=v1_name,
-            axis_xyz=(1, 0, 0),
-            pose=(0, sign * parent_lateral_y, parent_offset_z, 0, 0, 0),
-            lower_limit=flex_limits[0],
-            upper_limit=flex_limits[1],
+            coord_prefix=coord_prefix,
+            side=side,
+            sign=sign,
+            parent_link=parent_link,
+            link_name=link_name,
+            parent_offset_z=parent_offset_z,
+            parent_lateral_y=parent_lateral_y,
+            flex_limits=flex_limits,
+            adduct_limits=adduct_limits,
+            rotate_limits=rotate_limits,
+            adduct_label=adduct_label,
+            rotate_label=rotate_label,
         )
-        # Joint 2: adduction (Z-axis) -- virtual_1 to virtual_2
-        add_revolute_joint(
-            model,
-            name=f"{coord_prefix}_{side}_{adduct_label}",
-            parent=v1_name,
-            child=v2_name,
-            axis_xyz=(0, 0, 1),
-            pose=(0, 0, 0, 0, 0, 0),
-            lower_limit=adduct_limits[0],
-            upper_limit=adduct_limits[1],
-        )
-        # Joint 3: rotation (Y-axis) -- virtual_2 to child
-        add_revolute_joint(
-            model,
-            name=f"{coord_prefix}_{side}_{rotate_label}",
-            parent=v2_name,
-            child=link_name,
-            axis_xyz=(0, 1, 0),
-            pose=(0, 0, 0, 0, 0, 0),
-            lower_limit=rotate_limits[0],
-            upper_limit=rotate_limits[1],
-        )
+        # Record the virtual links so callers can inspect / query them
+        created[v1] = model.find(f"link[@name='{v1}']")  # type: ignore[assignment]
+        created[v2] = model.find(f"link[@name='{v2}']")  # type: ignore[assignment]
 
     return created
+
+
+def _add_2dof_joint_chain(
+    model: ET.Element,
+    *,
+    coord_prefix: str,
+    side: str,
+    sign: float,
+    parent_link: str,
+    link_name: str,
+    parent_offset_z: float,
+    parent_lateral_y: float,
+    flex_limits: tuple[float, float],
+    second_limits: tuple[float, float],
+    second_label: str,
+) -> str:
+    """Wire virtual link and joints for one side of a 2-DOF compound joint.
+
+    Creates one virtual link and two revolute joints:
+      parent -> flex (X) -> v1 -> {second_label} (Z) -> child.
+
+    Returns the name of the created virtual link.
+    """
+    v1_name = f"{coord_prefix}_{side}_virtual_1"
+    add_virtual_link(model, name=v1_name)
+    _add_flex_joint(
+        model,
+        f"{coord_prefix}_{side}_flex",
+        parent_link,
+        v1_name,
+        (0, sign * parent_lateral_y, parent_offset_z, 0, 0, 0),
+        flex_limits,
+    )
+    add_revolute_joint(
+        model,
+        name=f"{coord_prefix}_{side}_{second_label}",
+        parent=v1_name,
+        child=link_name,
+        axis_xyz=(0, 0, 1),
+        pose=(0, 0, 0, 0, 0, 0),
+        lower_limit=second_limits[0],
+        upper_limit=second_limits[1],
+    )
+    return v1_name
 
 
 def _add_compound_2dof_bilateral(
@@ -317,52 +424,28 @@ def _add_compound_2dof_bilateral(
       parent -> {prefix}_flex joint -> virtual_1 -> {prefix}_{second} joint -> child
     """
     mass, length, radius = _seg(spec, seg_name)
-    inertia = cylinder_inertia(mass, radius, length)
     created: dict[str, ET.Element] = {}
 
     for side, sign in [("l", -1.0), ("r", 1.0)]:
         link_name = f"{seg_name}_{side}"
         parent_link = f"{parent_name}_{side}" if "_" in parent_name else parent_name
-        v1_name = f"{coord_prefix}_{side}_virtual_1"
-
-        # Virtual link
-        created[v1_name] = add_virtual_link(model, name=v1_name)
-
-        # Real segment link
-        created[link_name] = add_link(
-            model,
-            name=link_name,
-            mass=mass,
-            mass_center=(0, 0, -length / 2.0),
-            inertia_xx=inertia[0],
-            inertia_yy=inertia[1],
-            inertia_zz=inertia[2],
-            visual_geometry=make_cylinder_geometry(radius, length),
-            collision_geometry=make_cylinder_geometry(radius, length),
+        created[link_name] = _make_cylinder_segment_link(
+            model, name=link_name, mass=mass, length=length, radius=radius
         )
-
-        # Joint 1: flexion (X-axis) -- parent to virtual_1
-        add_revolute_joint(
+        v1 = _add_2dof_joint_chain(
             model,
-            name=f"{coord_prefix}_{side}_flex",
-            parent=parent_link,
-            child=v1_name,
-            axis_xyz=(1, 0, 0),
-            pose=(0, sign * parent_lateral_y, parent_offset_z, 0, 0, 0),
-            lower_limit=flex_limits[0],
-            upper_limit=flex_limits[1],
+            coord_prefix=coord_prefix,
+            side=side,
+            sign=sign,
+            parent_link=parent_link,
+            link_name=link_name,
+            parent_offset_z=parent_offset_z,
+            parent_lateral_y=parent_lateral_y,
+            flex_limits=flex_limits,
+            second_limits=second_limits,
+            second_label=second_label,
         )
-        # Joint 2: second DOF (Z-axis) -- virtual_1 to child
-        add_revolute_joint(
-            model,
-            name=f"{coord_prefix}_{side}_{second_label}",
-            parent=v1_name,
-            child=link_name,
-            axis_xyz=(0, 0, 1),
-            pose=(0, 0, 0, 0, 0, 0),
-            lower_limit=second_limits[0],
-            upper_limit=second_limits[1],
-        )
+        created[v1] = model.find(f"link[@name='{v1}']")  # type: ignore[assignment]
 
     return created
 
@@ -410,23 +493,25 @@ def _build_pelvis(
     return links
 
 
-def _build_spine_and_head(
+def _build_lumbar_joints(
     model: ET.Element,
     spec: BodyModelSpec,
+    t_len: float,
 ) -> dict[str, ET.Element]:
-    """Stage 2: Create lumbar 3-DOF compound joint, torso, neck, and head.
+    """Create lumbar 3-DOF compound joints and the torso link.
 
-    Returns dict with torso, head, and lumbar virtual link elements.
+    Chain: pelvis -> lumbar_flex (X) -> v1 -> lumbar_lateral (Z)
+           -> v2 -> lumbar_rotate (Y) -> torso.
+
+    Returns dict containing torso, lumbar_virtual_1, lumbar_virtual_2.
     """
     links: dict[str, ET.Element] = {}
-
-    p_mass, p_len, p_rad = _seg(spec, "pelvis")
-    t_mass, t_len, t_rad = _seg(spec, "torso")
+    _p_mass, p_len, p_rad = _seg(spec, "pelvis")
+    t_mass, _t_len, t_rad = _seg(spec, "torso")
     t_inertia = rectangular_prism_inertia(t_mass, t_rad * 2, t_len, t_rad * 2)
 
     links["lumbar_virtual_1"] = add_virtual_link(model, name="lumbar_virtual_1")
     links["lumbar_virtual_2"] = add_virtual_link(model, name="lumbar_virtual_2")
-
     links["torso"] = add_link(
         model,
         name="torso",
@@ -468,11 +553,21 @@ def _build_spine_and_head(
         lower_limit=LUMBAR_ROTATE_LOWER,
         upper_limit=LUMBAR_ROTATE_UPPER,
     )
+    return links
 
-    # Head
+
+def _build_head_link(
+    model: ET.Element,
+    spec: BodyModelSpec,
+    t_len: float,
+) -> dict[str, ET.Element]:
+    """Create the head link and neck revolute joint.
+
+    Returns dict containing the head link element.
+    """
     h_mass, h_len, h_rad = _seg(spec, "head")
     h_inertia = cylinder_inertia(h_mass, h_rad, h_len)
-    links["head"] = add_link(
+    head_link = add_link(
         model,
         name="head",
         mass=h_mass,
@@ -493,7 +588,81 @@ def _build_spine_and_head(
         lower_limit=-NECK_RANGE_LIMIT,
         upper_limit=NECK_RANGE_LIMIT,
     )
+    return {"head": head_link}
+
+
+def _build_spine_and_head(
+    model: ET.Element,
+    spec: BodyModelSpec,
+) -> dict[str, ET.Element]:
+    """Stage 2: Create lumbar 3-DOF compound joint, torso, neck, and head.
+
+    Returns dict with torso, head, and lumbar virtual link elements.
+    """
+    _t_mass, t_len, _t_rad = _seg(spec, "torso")
+    links = _build_lumbar_joints(model, spec, t_len)
+    links.update(_build_head_link(model, spec, t_len))
     return links
+
+
+def _build_shoulders(
+    model: ET.Element,
+    spec: BodyModelSpec,
+    t_len: float,
+    t_rad: float,
+) -> dict[str, ET.Element]:
+    """Create bilateral 3-DOF shoulder joints and upper_arm links."""
+    return _add_compound_3dof_bilateral(
+        model,
+        spec,
+        seg_name="upper_arm",
+        parent_name="torso",
+        parent_offset_z=t_len * SHOULDER_HEIGHT_FRACTION,
+        parent_lateral_y=t_rad * SHOULDER_LATERAL_MULTIPLIER,
+        coord_prefix="shoulder",
+        flex_limits=(SHOULDER_FLEX_LOWER, SHOULDER_FLEX_UPPER),
+        adduct_limits=(SHOULDER_ADDUCT_LOWER, SHOULDER_ADDUCT_UPPER),
+        rotate_limits=(SHOULDER_ROTATE_LOWER, SHOULDER_ROTATE_UPPER),
+    )
+
+
+def _build_elbows(
+    model: ET.Element,
+    spec: BodyModelSpec,
+) -> dict[str, ET.Element]:
+    """Create bilateral 1-DOF elbow joints and forearm links."""
+    _ua_mass, ua_len, _ua_rad = _seg(spec, "upper_arm")
+    return _add_bilateral_limb(
+        model,
+        spec,
+        seg_name="forearm",
+        parent_name="upper_arm",
+        parent_offset_z=-ua_len,
+        parent_lateral_y=0,
+        coord_prefix="elbow",
+        range_min=0,
+        range_max=ELBOW_FLEXION_LIMIT,
+    )
+
+
+def _build_wrists(
+    model: ET.Element,
+    spec: BodyModelSpec,
+) -> dict[str, ET.Element]:
+    """Create bilateral 2-DOF wrist joints and hand links."""
+    _fa_mass, fa_len, _fa_rad = _seg(spec, "forearm")
+    return _add_compound_2dof_bilateral(
+        model,
+        spec,
+        seg_name="hand",
+        parent_name="forearm",
+        parent_offset_z=-fa_len,
+        parent_lateral_y=0,
+        coord_prefix="wrist",
+        flex_limits=(WRIST_FLEX_LOWER, WRIST_FLEX_UPPER),
+        second_limits=(WRIST_DEVIATE_LOWER, WRIST_DEVIATE_UPPER),
+        second_label="deviate",
+    )
 
 
 def _build_upper_limbs(
@@ -504,60 +673,72 @@ def _build_upper_limbs(
 
     Returns dict with upper_arm, forearm, hand, and virtual link elements.
     """
-    links: dict[str, ET.Element] = {}
     _t_mass, t_len, t_rad = _seg(spec, "torso")
-
-    # Shoulder (3-DOF compound)
-    shoulder_z = t_len * SHOULDER_HEIGHT_FRACTION
-    shoulder_y = t_rad * SHOULDER_LATERAL_MULTIPLIER
-    links.update(
-        _add_compound_3dof_bilateral(
-            model,
-            spec,
-            seg_name="upper_arm",
-            parent_name="torso",
-            parent_offset_z=shoulder_z,
-            parent_lateral_y=shoulder_y,
-            coord_prefix="shoulder",
-            flex_limits=(SHOULDER_FLEX_LOWER, SHOULDER_FLEX_UPPER),
-            adduct_limits=(SHOULDER_ADDUCT_LOWER, SHOULDER_ADDUCT_UPPER),
-            rotate_limits=(SHOULDER_ROTATE_LOWER, SHOULDER_ROTATE_UPPER),
-        )
-    )
-
-    # Elbow (1-DOF)
-    _ua_mass, ua_len, _ua_rad = _seg(spec, "upper_arm")
-    links.update(
-        _add_bilateral_limb(
-            model,
-            spec,
-            seg_name="forearm",
-            parent_name="upper_arm",
-            parent_offset_z=-ua_len,
-            parent_lateral_y=0,
-            coord_prefix="elbow",
-            range_min=0,
-            range_max=ELBOW_FLEXION_LIMIT,
-        )
-    )
-
-    # Wrist (2-DOF compound)
-    _fa_mass, fa_len, _fa_rad = _seg(spec, "forearm")
-    links.update(
-        _add_compound_2dof_bilateral(
-            model,
-            spec,
-            seg_name="hand",
-            parent_name="forearm",
-            parent_offset_z=-fa_len,
-            parent_lateral_y=0,
-            coord_prefix="wrist",
-            flex_limits=(WRIST_FLEX_LOWER, WRIST_FLEX_UPPER),
-            second_limits=(WRIST_DEVIATE_LOWER, WRIST_DEVIATE_UPPER),
-            second_label="deviate",
-        )
-    )
+    links: dict[str, ET.Element] = {}
+    links.update(_build_shoulders(model, spec, t_len, t_rad))
+    links.update(_build_elbows(model, spec))
+    links.update(_build_wrists(model, spec))
     return links
+
+
+def _build_hips(
+    model: ET.Element,
+    spec: BodyModelSpec,
+    p_len: float,
+    p_rad: float,
+) -> dict[str, ET.Element]:
+    """Create bilateral 3-DOF hip joints and thigh links."""
+    return _add_compound_3dof_bilateral(
+        model,
+        spec,
+        seg_name="thigh",
+        parent_name="pelvis",
+        parent_offset_z=-p_len / 2.0,
+        parent_lateral_y=p_rad * HIP_LATERAL_MULTIPLIER,
+        coord_prefix="hip",
+        flex_limits=(HIP_FLEX_LOWER, HIP_FLEX_UPPER),
+        adduct_limits=(HIP_ADDUCT_LOWER, HIP_ADDUCT_UPPER),
+        rotate_limits=(HIP_ROTATE_LOWER, HIP_ROTATE_UPPER),
+    )
+
+
+def _build_knees(
+    model: ET.Element,
+    spec: BodyModelSpec,
+) -> dict[str, ET.Element]:
+    """Create bilateral 1-DOF knee joints and shank links."""
+    _th_mass, th_len, _th_rad = _seg(spec, "thigh")
+    return _add_bilateral_limb(
+        model,
+        spec,
+        seg_name="shank",
+        parent_name="thigh",
+        parent_offset_z=-th_len,
+        parent_lateral_y=0,
+        coord_prefix="knee",
+        range_min=KNEE_FLEXION_LIMIT,
+        range_max=0,
+    )
+
+
+def _build_ankles(
+    model: ET.Element,
+    spec: BodyModelSpec,
+) -> dict[str, ET.Element]:
+    """Create bilateral 2-DOF ankle joints and foot links."""
+    _sh_mass, sh_len, _sh_rad = _seg(spec, "shank")
+    return _add_compound_2dof_bilateral(
+        model,
+        spec,
+        seg_name="foot",
+        parent_name="shank",
+        parent_offset_z=-sh_len,
+        parent_lateral_y=0,
+        coord_prefix="ankle",
+        flex_limits=(ANKLE_FLEX_LOWER, ANKLE_FLEX_UPPER),
+        second_limits=(ANKLE_INVERT_LOWER, ANKLE_INVERT_UPPER),
+        second_label="invert",
+    )
 
 
 def _build_lower_limbs(
@@ -568,58 +749,11 @@ def _build_lower_limbs(
 
     Returns dict with thigh, shank, foot, and virtual link elements.
     """
-    links: dict[str, ET.Element] = {}
     _p_mass, p_len, p_rad = _seg(spec, "pelvis")
-
-    # Hip (3-DOF compound)
-    hip_y = p_rad * HIP_LATERAL_MULTIPLIER
-    links.update(
-        _add_compound_3dof_bilateral(
-            model,
-            spec,
-            seg_name="thigh",
-            parent_name="pelvis",
-            parent_offset_z=-p_len / 2.0,
-            parent_lateral_y=hip_y,
-            coord_prefix="hip",
-            flex_limits=(HIP_FLEX_LOWER, HIP_FLEX_UPPER),
-            adduct_limits=(HIP_ADDUCT_LOWER, HIP_ADDUCT_UPPER),
-            rotate_limits=(HIP_ROTATE_LOWER, HIP_ROTATE_UPPER),
-        )
-    )
-
-    # Knee (1-DOF)
-    _th_mass, th_len, _th_rad = _seg(spec, "thigh")
-    links.update(
-        _add_bilateral_limb(
-            model,
-            spec,
-            seg_name="shank",
-            parent_name="thigh",
-            parent_offset_z=-th_len,
-            parent_lateral_y=0,
-            coord_prefix="knee",
-            range_min=KNEE_FLEXION_LIMIT,
-            range_max=0,
-        )
-    )
-
-    # Ankle (2-DOF compound)
-    _sh_mass, sh_len, _sh_rad = _seg(spec, "shank")
-    links.update(
-        _add_compound_2dof_bilateral(
-            model,
-            spec,
-            seg_name="foot",
-            parent_name="shank",
-            parent_offset_z=-sh_len,
-            parent_lateral_y=0,
-            coord_prefix="ankle",
-            flex_limits=(ANKLE_FLEX_LOWER, ANKLE_FLEX_UPPER),
-            second_limits=(ANKLE_INVERT_LOWER, ANKLE_INVERT_UPPER),
-            second_label="invert",
-        )
-    )
+    links: dict[str, ET.Element] = {}
+    links.update(_build_hips(model, spec, p_len, p_rad))
+    links.update(_build_knees(model, spec))
+    links.update(_build_ankles(model, spec))
     return links
 
 
@@ -653,47 +787,28 @@ def create_full_body(
 ) -> dict[str, ET.Element]:
     """Build the full-body model and append links/joints to the SDF model.
 
-    The build proceeds in five staged steps (issue #77):
-      1. Pelvis and world joint
-      2. Spine (lumbar 3-DOF), torso, neck, head
-      3. Upper limbs (shoulders, elbows, wrists)
-      4. Lower limbs (hips, knees, ankles)
-      5. Foot sole contact geometry
+    Five staged steps: (1) pelvis, (2) spine+head, (3) upper limbs,
+    (4) lower limbs, (5) foot contacts.
 
     Args:
         model: SDF model element to append to.
         spec: Anthropometric specification (defaults to 50th-percentile male).
-        pelvis_joint_type: Joint type for the world-to-pelvis connection.
-            Use ``"floating"`` (default) for unconstrained 6-DOF motion, or
-            ``"fixed"`` when the exercise constrains the pelvis externally
-            (e.g. bench press weld through the bench pad).
+        pelvis_joint_type: ``"floating"`` (default, 6-DOF) or ``"fixed"``
+            when the exercise constrains the pelvis externally.
 
     Returns dict of link name -> ET.Element for all created links.
     """
     if spec is None:
         spec = BodyModelSpec()
-
     logger.info(
         "Building full-body model: mass=%.1f kg, height=%.2f m",
         spec.total_mass,
         spec.height,
     )
-
     links: dict[str, ET.Element] = {}
-
-    # Stage 1: Pelvis
     links.update(_build_pelvis(model, spec, pelvis_joint_type))
-
-    # Stage 2: Spine and head
     links.update(_build_spine_and_head(model, spec))
-
-    # Stage 3: Upper limbs
     links.update(_build_upper_limbs(model, spec))
-
-    # Stage 4: Lower limbs
     links.update(_build_lower_limbs(model, spec))
-
-    # Stage 5: Foot contacts
     _build_foot_contacts(model, spec, links)
-
     return links

--- a/src/drake_models/shared/utils/sdf_helpers.py
+++ b/src/drake_models/shared/utils/sdf_helpers.py
@@ -265,6 +265,26 @@ def add_contact_geometry(
     return collision
 
 
+def _add_ground_contact_collision(
+    ground_link: ET.Element,
+    mu_static: float,
+    mu_dynamic: float,
+) -> None:
+    """Attach a rigid hydroelastic box collision to *ground_link*.
+
+    The box (100 m x 100 m x 0.1 m) approximates an infinite half-space.
+    """
+    collision = ET.SubElement(ground_link, "collision", name="ground_plane_collision")
+    ET.SubElement(collision, "pose").text = pose_str(0, 0, -0.05, 0, 0, 0)
+    geom = ET.SubElement(collision, "geometry")
+    box = ET.SubElement(geom, "box")
+    ET.SubElement(box, "size").text = vec3_str(100, 100, 0.1)
+    prox = ET.SubElement(collision, _drake_tag("proximity_properties"))
+    ET.SubElement(prox, _drake_tag("rigid_hydroelastic"))
+    ET.SubElement(prox, _drake_tag("mu_static")).text = f"{mu_static:.1f}"
+    ET.SubElement(prox, _drake_tag("mu_dynamic")).text = f"{mu_dynamic:.1f}"
+
+
 def add_ground_plane_contact(
     model: ET.Element,
     *,
@@ -273,9 +293,8 @@ def add_ground_plane_contact(
 ) -> ET.Element:
     """Add an infinite half-space ground plane with rigid hydroelastic contact.
 
-    Creates a ``ground_plane`` link welded to world at Z=0. The collision
-    uses ``<drake:rigid_hydroelastic/>`` (the ground is infinitely stiff)
-    and a large box to approximate the half-space.
+    Creates a ``ground_plane`` link welded to world at Z=0. Uses
+    ``<drake:rigid_hydroelastic/>`` (infinitely stiff ground).
 
     Args:
         model: SDF model element to append to.
@@ -294,20 +313,7 @@ def add_ground_plane_contact(
         inertia_yy=1e-6,
         inertia_zz=1e-6,
     )
-
-    # Large box approximating infinite half-space (100m x 100m x 0.1m)
-    collision = ET.SubElement(ground_link, "collision", name="ground_plane_collision")
-    ET.SubElement(collision, "pose").text = pose_str(0, 0, -0.05, 0, 0, 0)
-    geom = ET.SubElement(collision, "geometry")
-    box = ET.SubElement(geom, "box")
-    ET.SubElement(box, "size").text = vec3_str(100, 100, 0.1)
-
-    prox = ET.SubElement(collision, _drake_tag("proximity_properties"))
-    ET.SubElement(prox, _drake_tag("rigid_hydroelastic"))
-    ET.SubElement(prox, _drake_tag("mu_static")).text = f"{mu_static:.1f}"
-    ET.SubElement(prox, _drake_tag("mu_dynamic")).text = f"{mu_dynamic:.1f}"
-
-    # Weld ground plane to world at Z=0
+    _add_ground_contact_collision(ground_link, mu_static, mu_dynamic)
     add_fixed_joint(
         model,
         name="ground_plane_weld",
@@ -315,7 +321,6 @@ def add_ground_plane_contact(
         child="ground_plane",
         pose=(0, 0, 0, 0, 0, 0),
     )
-
     logger.debug("Added ground plane with rigid hydroelastic contact")
     return ground_link
 

--- a/tests/unit/exercises/test_sit_to_stand.py
+++ b/tests/unit/exercises/test_sit_to_stand.py
@@ -3,7 +3,7 @@
 import math
 import xml.etree.ElementTree as ET
 
-from drake_models.exercises.base import ExerciseConfig
+from drake_models.exercises.base import ExerciseConfig, ExerciseModelBuilder
 from drake_models.exercises.sit_to_stand.sit_to_stand_model import (
     SitToStandModelBuilder,
     build_sit_to_stand_model,
@@ -99,3 +99,52 @@ class TestSitToStandModelBuilder:
         model = root.find(".//model")  # type: ignore
         assert model is not None
         assert model.get("name") == "sit_to_stand"  # type: ignore
+
+
+class TestMakeChairSeatLink:
+    """Tests for the extracted _make_chair_seat_link and _add_chair_contact helpers."""
+
+    def test_make_chair_seat_link_creates_link(self) -> None:
+        model = ET.Element("model")
+        link = SitToStandModelBuilder._make_chair_seat_link(model)
+        assert link.tag == "link"
+        assert link.get("name") == "chair_seat"  # type: ignore
+
+    def test_make_chair_seat_link_has_geometry(self) -> None:
+        model = ET.Element("model")
+        link = SitToStandModelBuilder._make_chair_seat_link(model)
+        assert link.find("visual") is not None  # type: ignore
+        assert link.find("collision") is not None  # type: ignore
+
+    def test_add_chair_contact_attaches_collision(self) -> None:
+        model = ET.Element("model")
+        link = SitToStandModelBuilder._make_chair_seat_link(model)
+        initial_collisions = len(link.findall("collision"))  # type: ignore
+        SitToStandModelBuilder._add_chair_contact(link)
+        after_collisions = len(link.findall("collision"))  # type: ignore
+        assert after_collisions == initial_collisions + 1
+
+
+class TestBilateralCollisionPairs:
+    """Tests for the extracted _bilateral_collision_pairs helper."""
+
+    def test_returns_six_pairs_per_side(self) -> None:
+        pairs = ExerciseModelBuilder._bilateral_collision_pairs("l")
+        assert len(pairs) == 6
+
+    def test_all_pairs_have_name_and_members(self) -> None:
+        for side in ("l", "r"):
+            pairs = ExerciseModelBuilder._bilateral_collision_pairs(side)
+            for name, members in pairs:
+                assert isinstance(name, str)
+                assert len(members) >= 2
+
+    def test_left_side_uses_l_suffix(self) -> None:
+        pairs = ExerciseModelBuilder._bilateral_collision_pairs("l")
+        names = [name for name, _ in pairs]
+        assert all("_l" in name or name.startswith("torso") for name in names)
+
+    def test_right_side_uses_r_suffix(self) -> None:
+        pairs = ExerciseModelBuilder._bilateral_collision_pairs("r")
+        names = [name for name, _ in pairs]
+        assert all("_r" in name for name in names)

--- a/tests/unit/optimization/test_inverse_kinematics.py
+++ b/tests/unit/optimization/test_inverse_kinematics.py
@@ -4,7 +4,40 @@ import numpy as np
 import pytest
 
 from drake_models.optimization.exercise_objectives import SQUAT, get_objective
-from drake_models.optimization.inverse_kinematics import solve_ik_keyframes
+from drake_models.optimization.inverse_kinematics import (
+    _interpolate_phases,
+    _pydrake_available,
+    solve_ik_keyframes,
+)
+
+
+class TestPydrakeAvailable:
+    """Tests for the extracted _pydrake_available helper."""
+
+    def test_returns_bool(self) -> None:
+        result = _pydrake_available()
+        assert isinstance(result, bool)
+
+    def test_false_without_pydrake(self) -> None:
+        # In the test environment pydrake is not installed.
+        assert _pydrake_available() is False
+
+
+class TestInterpolatePhases:
+    """Tests for the _interpolate_phases helper."""
+
+    def test_output_shape(self) -> None:
+        keyframes = _interpolate_phases(SQUAT, n_frames=20)
+        n_joints = len(SQUAT.joint_names())
+        assert keyframes.shape == (20, n_joints)
+
+    def test_all_finite(self) -> None:
+        keyframes = _interpolate_phases(SQUAT, n_frames=15)
+        assert np.all(np.isfinite(keyframes))
+
+    def test_n_frames_too_small(self) -> None:
+        with pytest.raises(ValueError, match="n_frames"):
+            _interpolate_phases(SQUAT, n_frames=1)
 
 
 class TestSolveIkKeyframes:

--- a/tests/unit/optimization/test_trajectory_optimizer.py
+++ b/tests/unit/optimization/test_trajectory_optimizer.py
@@ -7,6 +7,10 @@ from drake_models.optimization.exercise_objectives import SQUAT, get_objective
 from drake_models.optimization.trajectory_optimizer import (
     TrajectoryConfig,
     TrajectoryResult,
+    _build_phase_arrays,
+    _compute_interpolated_cost,
+    _finite_diff_velocities,
+    _interpolate_joint_positions,
     compute_control_cost,
     compute_state_cost,
     compute_terminal_cost,
@@ -247,6 +251,92 @@ class TestInterpolateTrajectory:
             result = interpolate_trajectory(obj, cfg)
             assert result.converged
             assert result.joint_positions.shape[0] == 20
+
+
+class TestBuildPhaseArrays:
+    """Tests for the extracted _build_phase_arrays helper."""
+
+    def test_returns_tuple_of_arrays(self) -> None:
+        phase_times, phase_angles = _build_phase_arrays(SQUAT)
+        assert phase_times.shape[0] == len(SQUAT.phases)
+        assert phase_angles.shape[0] == len(SQUAT.phases)
+
+    def test_no_nans_in_clean_angles(self) -> None:
+        _phase_times, phase_angles = _build_phase_arrays(SQUAT)
+        assert not np.any(np.isnan(phase_angles))
+
+    def test_phase_times_sorted(self) -> None:
+        phase_times, _ = _build_phase_arrays(SQUAT)
+        assert np.all(np.diff(phase_times) >= 0)
+
+
+class TestInterpolateJointPositions:
+    """Tests for the extracted _interpolate_joint_positions helper."""
+
+    def test_output_shape(self) -> None:
+        phase_times, phase_angles = _build_phase_arrays(SQUAT)
+        n_joints = phase_angles.shape[1]
+        time_fracs = np.linspace(0.0, 1.0, 30)
+        positions = _interpolate_joint_positions(
+            phase_times, phase_angles, time_fracs, n_joints
+        )
+        assert positions.shape == (30, n_joints)
+
+    def test_all_finite(self) -> None:
+        phase_times, phase_angles = _build_phase_arrays(SQUAT)
+        n_joints = phase_angles.shape[1]
+        time_fracs = np.linspace(0.0, 1.0, 20)
+        positions = _interpolate_joint_positions(
+            phase_times, phase_angles, time_fracs, n_joints
+        )
+        assert np.all(np.isfinite(positions))
+
+
+class TestFiniteDiffVelocities:
+    """Tests for the extracted _finite_diff_velocities helper."""
+
+    def test_first_row_is_zero(self) -> None:
+        positions = np.ones((10, 4))
+        velocities = _finite_diff_velocities(positions, dt=0.01)
+        assert np.all(velocities[0] == 0.0)
+
+    def test_constant_positions_give_zero_velocities(self) -> None:
+        positions = np.ones((10, 4))
+        velocities = _finite_diff_velocities(positions, dt=0.01)
+        assert np.all(velocities[1:] == 0.0)
+
+    def test_linear_positions_give_constant_velocity(self) -> None:
+        dt = 0.1
+        positions = np.outer(np.arange(10), np.ones(4))  # each col = 0,1,...,9
+        velocities = _finite_diff_velocities(positions, dt=dt)
+        # expected velocity = 1/dt everywhere (except row 0)
+        assert np.allclose(velocities[1:], 1.0 / dt)
+
+    def test_output_shape_matches_input(self) -> None:
+        positions = np.zeros((15, 6))
+        velocities = _finite_diff_velocities(positions, dt=0.05)
+        assert velocities.shape == (15, 6)
+
+
+class TestComputeInterpolatedCost:
+    """Tests for the extracted _compute_interpolated_cost helper."""
+
+    def test_zero_cost_for_zero_torques_at_target(self) -> None:
+        cfg = TrajectoryConfig(n_timesteps=10, dt=0.01)
+        positions = np.zeros((10, 3))
+        torques = np.zeros((10, 3))
+        terminal_target = np.zeros(3)
+        cost = _compute_interpolated_cost(positions, torques, terminal_target, cfg)
+        assert cost == pytest.approx(0.0)
+
+    def test_nonzero_terminal_cost(self) -> None:
+        cfg = TrajectoryConfig(n_timesteps=10, dt=0.01, terminal_weight=1.0)
+        positions = np.zeros((10, 1))
+        positions[-1, 0] = 1.0  # final position deviates
+        torques = np.zeros((10, 1))
+        terminal_target = np.zeros(1)
+        cost = _compute_interpolated_cost(positions, torques, terminal_target, cfg)
+        assert cost > 0.0
 
 
 class TestCreateTrajectoryOptimization:

--- a/tests/unit/shared/test_barbell.py
+++ b/tests/unit/shared/test_barbell.py
@@ -6,6 +6,12 @@ from typing import Any
 import pytest
 
 from drake_models.shared.barbell import BarbellSpec, create_barbell_links
+from drake_models.shared.barbell.barbell_model import (
+    _compute_sleeve_inertia,
+    _make_shaft_link,
+    _make_sleeve_link,
+    _weld_sleeves,
+)
 
 
 class TestBarbellSpec:
@@ -160,3 +166,113 @@ class TestCreateBarbellLinks:
         for link in model.findall("link"):
             mass = float(link.find("inertial/mass").text)  # type: ignore
             assert mass > 0, f"{link.get('name')} mass={mass}"  # type: ignore
+
+
+class TestComputeSleeveInertia:
+    """Tests for the extracted _compute_sleeve_inertia helper."""
+
+    def test_returns_tuple_and_mass(self) -> None:
+        spec = BarbellSpec.mens_olympic()
+        inertia, total_mass = _compute_sleeve_inertia(spec)
+        assert len(inertia) == 3
+        assert total_mass == pytest.approx(spec.sleeve_mass)
+
+    def test_includes_plate_mass(self) -> None:
+        spec = BarbellSpec.mens_olympic(plate_mass_per_side=20.0)
+        inertia, total_mass = _compute_sleeve_inertia(spec)
+        assert total_mass == pytest.approx(spec.sleeve_mass + 20.0)
+
+    def test_inertia_increases_with_plates(self) -> None:
+        spec_bare = BarbellSpec.mens_olympic()
+        spec_loaded = BarbellSpec.mens_olympic(plate_mass_per_side=20.0)
+        inertia_bare, _ = _compute_sleeve_inertia(spec_bare)
+        inertia_loaded, _ = _compute_sleeve_inertia(spec_loaded)
+        # All components should be larger when plates are added
+        assert all(inertia_loaded[i] > inertia_bare[i] for i in range(3))
+
+
+class TestMakeSleeveLink:
+    """Tests for the extracted _make_sleeve_link helper."""
+
+    def test_creates_link_with_correct_name(self) -> None:
+        model = ET.Element("model")
+        spec = BarbellSpec.mens_olympic()
+        inertia, mass = _compute_sleeve_inertia(spec)
+        link = _make_sleeve_link(
+            model,
+            "barbell_left_sleeve",
+            mass,
+            inertia,
+            spec.sleeve_radius,
+            spec.sleeve_length,
+        )
+        assert link.get("name") == "barbell_left_sleeve"  # type: ignore
+
+    def test_has_y_aligned_cylinder(self) -> None:
+        import math
+
+        model = ET.Element("model")
+        spec = BarbellSpec.mens_olympic()
+        inertia, mass = _compute_sleeve_inertia(spec)
+        link = _make_sleeve_link(
+            model,
+            "s",
+            mass,
+            inertia,
+            spec.sleeve_radius,
+            spec.sleeve_length,
+        )
+        # Y-aligned cylinders include a pose with roll=pi/2
+        xml_str = ET.tostring(link, encoding="unicode")
+        assert str(round(math.pi / 2, 4))[:4] in xml_str  # type: ignore
+
+
+class TestMakeShaftLink:
+    """Tests for the extracted _make_shaft_link helper."""
+
+    def test_creates_link_with_shaft_mass(self) -> None:
+        model = ET.Element("model")
+        spec = BarbellSpec.mens_olympic()
+        from drake_models.shared.barbell.barbell_model import _cylinder_inertia_y_axis
+
+        inertia = _cylinder_inertia_y_axis(
+            spec.shaft_mass, spec.shaft_radius, spec.shaft_length
+        )
+        link = _make_shaft_link(model, "barbell_shaft", spec, inertia)
+        mass_el = link.find("inertial/mass")  # type: ignore
+        assert float(mass_el.text) == pytest.approx(spec.shaft_mass)  # type: ignore
+
+
+class TestWeldSleeves:
+    """Tests for the extracted _weld_sleeves helper."""
+
+    def test_adds_two_fixed_joints(self) -> None:
+        model = ET.Element("model")
+        _weld_sleeves(
+            model,
+            "barbell",
+            "barbell_shaft",
+            "barbell_left_sleeve",
+            "barbell_right_sleeve",
+            0.655,
+            0.2225,
+        )
+        joints = model.findall("joint[@type='fixed']")  # type: ignore
+        assert len(joints) == 2
+
+    def test_left_at_negative_y(self) -> None:
+        model = ET.Element("model")
+        _weld_sleeves(
+            model,
+            "barbell",
+            "barbell_shaft",
+            "barbell_left_sleeve",
+            "barbell_right_sleeve",
+            0.655,
+            0.2225,
+        )
+        for joint in model.findall("joint"):
+            if joint.get("name") == "barbell_left_weld":  # type: ignore
+                pose_text = joint.find("pose").text  # type: ignore
+                y_val = float(pose_text.split()[1])
+                assert y_val < 0  # type: ignore

--- a/tests/unit/shared/test_body_model.py
+++ b/tests/unit/shared/test_body_model.py
@@ -6,6 +6,17 @@ from typing import Any
 import pytest
 
 from drake_models.shared.body import BodyModelSpec, create_full_body
+from drake_models.shared.body.body_model import (
+    _build_ankles,
+    _build_elbows,
+    _build_head_link,
+    _build_hips,
+    _build_knees,
+    _build_lumbar_joints,
+    _build_shoulders,
+    _build_wrists,
+    _make_cylinder_segment_link,
+)
 
 
 class TestBodyModelSpec:
@@ -231,3 +242,140 @@ class TestCreateFullBody:
         )
         # 14 virtual links * 1e-6 kg = 14e-6 kg added
         assert total == pytest.approx(80.0, abs=1e-3)
+
+
+class TestMakeCylinderSegmentLink:
+    """Tests for the extracted _make_cylinder_segment_link helper."""
+
+    def test_creates_link_element(self) -> None:
+        model = ET.Element("model")
+        link = _make_cylinder_segment_link(
+            model, name="thigh_l", mass=8.0, length=0.42, radius=0.06
+        )
+        assert link.tag == "link"
+        assert link.get("name") == "thigh_l"  # type: ignore
+
+    def test_has_inertial_block(self) -> None:
+        model = ET.Element("model")
+        link = _make_cylinder_segment_link(
+            model, name="shank_r", mass=3.76, length=0.43, radius=0.044
+        )
+        inertial = link.find("inertial")  # type: ignore
+        assert inertial is not None
+
+    def test_mass_center_at_minus_half_length(self) -> None:
+        model = ET.Element("model")
+        length = 0.40
+        link = _make_cylinder_segment_link(
+            model, name="thigh_l", mass=8.0, length=length, radius=0.06
+        )
+        pose = link.find("inertial/pose")  # type: ignore
+        assert pose is not None
+        z_val = float(pose.text.split()[2])  # type: ignore
+        assert z_val == pytest.approx(-length / 2.0)
+
+    def test_has_visual_geometry(self) -> None:
+        model = ET.Element("model")
+        link = _make_cylinder_segment_link(
+            model, name="upper_arm_l", mass=2.24, length=0.33, radius=0.04
+        )
+        assert link.find("visual") is not None  # type: ignore
+
+    def test_has_collision_geometry(self) -> None:
+        model = ET.Element("model")
+        link = _make_cylinder_segment_link(
+            model, name="upper_arm_r", mass=2.24, length=0.33, radius=0.04
+        )
+        assert link.find("collision") is not None  # type: ignore
+
+
+class TestBuildStagedHelpers:
+    """Tests for the staged body-model builder helpers (extracted from issue #92)."""
+
+    @pytest.fixture()
+    def model_and_spec(self) -> tuple[ET.Element, BodyModelSpec]:
+        model = ET.Element("model", name="test")
+        spec = BodyModelSpec()
+        return model, spec
+
+    def test_build_shoulders_creates_upper_arm_links(self, model_and_spec: Any) -> None:
+        model, spec = model_and_spec
+        from drake_models.shared.body.body_model import _seg
+
+        _t_mass, t_len, t_rad = _seg(spec, "torso")
+        links = _build_shoulders(model, spec, t_len, t_rad)
+        assert "upper_arm_l" in links  # type: ignore
+        assert "upper_arm_r" in links  # type: ignore
+
+    def test_build_elbows_creates_forearm_links(self, model_and_spec: Any) -> None:
+        model, spec = model_and_spec
+        # elbows need upper_arm links first for chain validation-free test
+        links = _build_elbows(model, spec)
+        assert "forearm_l" in links  # type: ignore
+        assert "forearm_r" in links  # type: ignore
+
+    def test_build_wrists_creates_hand_links(self, model_and_spec: Any) -> None:
+        model, spec = model_and_spec
+        links = _build_wrists(model, spec)
+        assert "hand_l" in links  # type: ignore
+        assert "hand_r" in links  # type: ignore
+
+    def test_build_hips_creates_thigh_links(self, model_and_spec: Any) -> None:
+        model, spec = model_and_spec
+        from drake_models.shared.body.body_model import _seg
+
+        _p_mass, p_len, p_rad = _seg(spec, "pelvis")
+        links = _build_hips(model, spec, p_len, p_rad)
+        assert "thigh_l" in links  # type: ignore
+        assert "thigh_r" in links  # type: ignore
+
+    def test_build_knees_creates_shank_links(self, model_and_spec: Any) -> None:
+        model, spec = model_and_spec
+        links = _build_knees(model, spec)
+        assert "shank_l" in links  # type: ignore
+        assert "shank_r" in links  # type: ignore
+
+    def test_build_ankles_creates_foot_links(self, model_and_spec: Any) -> None:
+        model, spec = model_and_spec
+        links = _build_ankles(model, spec)
+        assert "foot_l" in links  # type: ignore
+        assert "foot_r" in links  # type: ignore
+
+    def test_build_lumbar_joints_creates_torso(self, model_and_spec: Any) -> None:
+        model, spec = model_and_spec
+        from drake_models.shared.body.body_model import _seg
+
+        _t_mass, t_len, _t_rad = _seg(spec, "torso")
+        links = _build_lumbar_joints(model, spec, t_len)
+        assert "torso" in links  # type: ignore
+        assert "lumbar_virtual_1" in links  # type: ignore
+        assert "lumbar_virtual_2" in links  # type: ignore
+
+    def test_build_lumbar_joints_adds_three_joints(self, model_and_spec: Any) -> None:
+        model, spec = model_and_spec
+        from drake_models.shared.body.body_model import _seg
+
+        _t_mass, t_len, _t_rad = _seg(spec, "torso")
+        _build_lumbar_joints(model, spec, t_len)
+        joint_names = {j.get("name") for j in model.findall("joint")}  # type: ignore
+        assert "lumbar_flex" in joint_names  # type: ignore
+        assert "lumbar_lateral" in joint_names  # type: ignore
+        assert "lumbar_rotate" in joint_names  # type: ignore
+
+    def test_build_head_link_creates_head(self, model_and_spec: Any) -> None:
+        model, spec = model_and_spec
+        # Build torso first so neck joint can reference it
+        from drake_models.shared.body.body_model import _seg
+
+        _t_mass, t_len, _t_rad = _seg(spec, "torso")
+        links = _build_head_link(model, spec, t_len)
+        assert "head" in links  # type: ignore
+
+    def test_build_head_link_adds_neck_joint(self, model_and_spec: Any) -> None:
+        model, spec = model_and_spec
+        from drake_models.shared.body.body_model import _seg
+
+        _t_mass, t_len, _t_rad = _seg(spec, "torso")
+        _build_head_link(model, spec, t_len)
+        joint_names = {j.get("name") for j in model.findall("joint")}  # type: ignore
+        assert "neck" in joint_names  # type: ignore

--- a/tests/unit/shared/test_sdf_helpers.py
+++ b/tests/unit/shared/test_sdf_helpers.py
@@ -6,8 +6,10 @@ from typing import Any
 import pytest
 
 from drake_models.shared.utils.sdf_helpers import (
+    _add_ground_contact_collision,
     add_fixed_joint,
     add_floating_joint,
+    add_ground_plane_contact,
     add_link,
     add_revolute_joint,
     add_virtual_link,
@@ -360,3 +362,57 @@ class TestSerializeModel:
         result = serialize_model(root)
         parsed = ET.fromstring(result)
         assert parsed.tag == "sdf"
+
+
+class TestAddGroundContactCollision:
+    """Tests for the extracted _add_ground_contact_collision helper."""
+
+    def _make_link(self) -> ET.Element:
+        model = ET.Element("model")
+        return add_link(
+            model,
+            name="ground_plane",
+            mass=1e-6,
+            mass_center=(0, 0, 0),
+            inertia_xx=1e-6,
+            inertia_yy=1e-6,
+            inertia_zz=1e-6,
+        )
+
+    def test_creates_collision_element(self) -> None:
+        link = self._make_link()
+        _add_ground_contact_collision(link, mu_static=0.8, mu_dynamic=0.6)
+        collision = link.find("collision[@name='ground_plane_collision']")  # type: ignore
+        assert collision is not None
+
+    def test_has_box_geometry(self) -> None:
+        link = self._make_link()
+        _add_ground_contact_collision(link, mu_static=0.8, mu_dynamic=0.6)
+        box = link.find(".//geometry/box")  # type: ignore
+        assert box is not None
+
+    def test_friction_values_written(self) -> None:
+        link = self._make_link()
+        _add_ground_contact_collision(link, mu_static=0.7, mu_dynamic=0.5)
+        xml_str = ET.tostring(link, encoding="unicode")
+        assert "0.7" in xml_str  # type: ignore
+        assert "0.5" in xml_str  # type: ignore
+
+
+class TestAddGroundPlaneContactHelper:
+    """Integration tests for add_ground_plane_contact (53-line -> 2 helpers)."""
+
+    def test_returns_link_element(self) -> None:
+        model = ET.Element("model")
+        link = add_ground_plane_contact(model)
+        assert link.tag == "link"
+        assert link.get("name") == "ground_plane"  # type: ignore
+
+    def test_weld_joint_added(self) -> None:
+        model = ET.Element("model")
+        add_ground_plane_contact(model)
+        joints = [
+            j for j in model.findall("joint") if j.get("name") == "ground_plane_weld"
+        ]  # type: ignore
+        assert len(joints) == 1
+        assert joints[0].find("parent").text == "world"  # type: ignore

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -2,13 +2,120 @@
 
 from __future__ import annotations
 
+import argparse
 import xml.etree.ElementTree as ET
 from io import StringIO
 from unittest.mock import patch
 
 import pytest
 
-from drake_models.__main__ import main
+from drake_models.__main__ import (
+    _build_arg_parser,
+    _validate_args,
+    _write_output,
+    main,
+)
+
+
+class TestBuildArgParser:
+    """Tests for the extracted _build_arg_parser helper."""
+
+    def test_returns_argument_parser(self) -> None:
+        parser = _build_arg_parser()
+        assert isinstance(parser, argparse.ArgumentParser)
+
+    def test_has_exercise_argument(self) -> None:
+        parser = _build_arg_parser()
+        args = parser.parse_args(["squat"])
+        assert args.exercise == "squat"
+
+    def test_has_mass_default(self) -> None:
+        parser = _build_arg_parser()
+        args = parser.parse_args(["squat"])
+        assert args.mass == 80.0  # type: ignore
+
+    def test_has_height_default(self) -> None:
+        parser = _build_arg_parser()
+        args = parser.parse_args(["squat"])
+        assert args.height == 1.75  # type: ignore
+
+    def test_has_plates_default(self) -> None:
+        parser = _build_arg_parser()
+        args = parser.parse_args(["squat"])
+        assert args.plates == 60.0  # type: ignore
+
+    def test_verbose_flag(self) -> None:
+        parser = _build_arg_parser()
+        args = parser.parse_args(["squat", "-v"])
+        assert args.verbose is True
+
+    def test_output_flag(self) -> None:
+        parser = _build_arg_parser()
+        args = parser.parse_args(["squat", "-o", "out.sdf"])
+        assert args.output == "out.sdf"
+
+
+class TestValidateArgs:
+    """Tests for the extracted _validate_args helper."""
+
+    def _parse(self, argv: list[str]) -> argparse.Namespace:
+        return _build_arg_parser().parse_args(argv)
+
+    def test_valid_args_pass(self) -> None:
+        parser = _build_arg_parser()
+        args = self._parse(["squat", "--mass", "80", "--height", "1.75"])
+        _validate_args(parser, args)  # should not raise
+
+    def test_zero_mass_raises_system_exit(self) -> None:
+        parser = _build_arg_parser()
+        args = self._parse(["squat"])
+        args.mass = 0.0
+        with pytest.raises(SystemExit):
+            _validate_args(parser, args)
+
+    def test_negative_mass_raises_system_exit(self) -> None:
+        parser = _build_arg_parser()
+        args = self._parse(["squat"])
+        args.mass = -1.0
+        with pytest.raises(SystemExit):
+            _validate_args(parser, args)
+
+    def test_zero_height_raises_system_exit(self) -> None:
+        parser = _build_arg_parser()
+        args = self._parse(["squat"])
+        args.height = 0.0
+        with pytest.raises(SystemExit):
+            _validate_args(parser, args)
+
+    def test_negative_plates_raises_system_exit(self) -> None:
+        parser = _build_arg_parser()
+        args = self._parse(["squat"])
+        args.plates = -1.0
+        with pytest.raises(SystemExit):
+            _validate_args(parser, args)
+
+    def test_zero_plates_is_valid(self) -> None:
+        parser = _build_arg_parser()
+        args = self._parse(["squat"])
+        args.plates = 0.0
+        _validate_args(parser, args)  # should not raise
+
+
+class TestWriteOutput:
+    """Tests for the extracted _write_output helper."""
+
+    def test_writes_to_stdout_when_no_path(self) -> None:
+        with patch("sys.stdout", new_callable=StringIO) as mock_out:
+            _write_output("<sdf/>", None)
+        assert "<sdf/>" in mock_out.getvalue()
+
+    def test_writes_to_file(self, tmp_path: object) -> None:
+        import pathlib
+
+        assert isinstance(tmp_path, pathlib.Path)
+        out_file = tmp_path / "out.sdf"
+        _write_output("<sdf/>", str(out_file))
+        assert out_file.read_text() == "<sdf/>"
 
 
 class TestCLI:


### PR DESCRIPTION
## Summary

- Refactored 16 functions across 8 source files that exceeded the 50-line limit enforced in CI
- Each long function was split into focused, single-responsibility helpers with clear names and docstrings
- New unit tests added for every extracted helper to maintain and improve coverage (91% total)

## Files changed

- `src/drake_models/__main__.py`: extracted `_build_arg_parser`, `_validate_args`, `_write_output` from `main`
- `src/drake_models/exercises/base.py`: extracted `_bilateral_collision_pairs` from `_add_collision_filters`
- `src/drake_models/exercises/sit_to_stand/sit_to_stand_model.py`: extracted `_make_chair_seat_link`, `_add_chair_contact` from `_add_chair_body`
- `src/drake_models/optimization/trajectory_optimizer.py`: extracted `_build_phase_arrays`, `_compute_interpolated_cost`, `_interpolate_joint_positions`, `_finite_diff_velocities`, `_try_drake_solve`, `_build_drake_plant`, `_add_control_costs`, `_add_phase_tracking_costs`
- `src/drake_models/optimization/inverse_kinematics.py`: extracted `_pydrake_available`, `_build_ik_plant`, `_refine_keyframe`
- `src/drake_models/shared/barbell/barbell_model.py`: extracted `_compute_sleeve_inertia`, `_make_sleeve_link`, `_make_shaft_link`, `_weld_sleeves`
- `src/drake_models/shared/body/body_model.py`: extracted `_make_cylinder_segment_link`, `_add_flex_joint`, `_add_3dof_joint_chain`, `_add_2dof_joint_chain`, `_build_lumbar_joints`, `_build_head_link`, `_build_shoulders`, `_build_elbows`, `_build_wrists`, `_build_hips`, `_build_knees`, `_build_ankles`
- `src/drake_models/shared/utils/sdf_helpers.py`: extracted `_add_ground_contact_collision` from `add_ground_plane_contact`

## Test plan

- [x] `ruff check src tests` — zero violations
- [x] `ruff format --check src tests` — zero diffs
- [x] `mypy src` — zero errors (44 source files checked)
- [x] `pytest --cov=src --cov-fail-under=80` — 681 passed, 27 skipped, 91.13% coverage
- [x] Zero functions exceeding 50 lines (verified via AST measurement)

Closes #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)