### PR TITLE
ci: add Rust CI pipeline (cargo test, clippy --all-targets, fmt --check)

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -44,6 +44,7 @@ jobs:
   rust-check:
     needs: pick-runner
     runs-on: ${{ needs.pick-runner.outputs.runner }}
+    timeout-minutes: 15
     defaults:
       run:
         working-directory: rust_core
@@ -61,8 +62,8 @@ jobs:
             rust_core/target
           key: ${{ runner.os }}-cargo-${{ hashFiles('rust_core/Cargo.lock') }}
       - name: Check Formatting
-        run: cargo fmt -- --check
+        run: cargo fmt --check
       - name: Clippy
-        run: cargo clippy -- -D warnings
+        run: cargo clippy --all-targets -- -D warnings
       - name: Tests
         run: cargo test


### PR DESCRIPTION
## Summary

- Fixes `cargo fmt` command: changed `cargo fmt -- --check` to `cargo fmt --check` (correct syntax)
- Adds `--all-targets` flag to `cargo clippy` as specified in issue #91
- Adds `timeout-minutes: 15` to the `rust-check` job to match the pattern in `ci-standard.yml`
- Workflow already had the `paths: rust_core/**` filter, self-hosted runner dispatcher, and cargo caching in place

Closes #91

## Test plan

- [ ] Verify CI workflow triggers only when files under `rust_core/` are modified
- [ ] Confirm `cargo fmt --check` passes on the existing Rust source
- [ ] Confirm `cargo clippy --all-targets -- -D warnings` passes with no warnings
- [ ] Confirm `cargo test` passes all tests in `rust_core/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)