### PR TITLE
refactor(objectives): add bilateral joint-angle helper (fixes #123)

### DIFF
--- a/src/drake_models/optimization/objectives/_helpers.py
+++ b/src/drake_models/optimization/objectives/_helpers.py
@@ -1,0 +1,59 @@
+"""Internal helpers shared by exercise objective phase definitions.
+
+These helpers exist purely to reduce duplication in the ``phases`` tables
+of the per-exercise objective modules. They are intentionally private
+(leading underscore) because callers outside the ``objectives`` package
+should continue to depend on :class:`ExercisePhase` / :class:`ExerciseObjective`
+rather than the construction helpers themselves.
+"""
+
+from __future__ import annotations
+
+import math
+
+
+def bilateral(
+    prefix: str,
+    degrees: float,
+    *,
+    suffix: str = "",
+) -> dict[str, float]:
+    """Return a symmetric left/right joint-angle dict in radians.
+
+    Many exercise objective phases specify the same target angle for the
+    left and right side of a bilateral joint (e.g. both hips flexed to
+    90 degrees during a squat). This helper converts a single degree
+    value into the paired radian dict expected by
+    :class:`drake_models.optimization.objectives.ExercisePhase`, following
+    the repository naming convention of ``{prefix}_{l|r}[_{suffix}]``.
+
+    Args:
+        prefix: The joint-name segment that precedes the side marker,
+            e.g. ``"hip"``, ``"knee"``, or ``"ankle"``.
+        degrees: Target angle in degrees, applied identically to both sides.
+        suffix: Optional joint-name segment that follows the side marker,
+            e.g. ``"flex"``. When empty, the key is just ``{prefix}_{side}``.
+
+    Returns:
+        A fresh dict with two entries, one for each side. With
+        ``prefix="hip"`` and ``suffix="flex"`` the keys are ``hip_l_flex``
+        and ``hip_r_flex``. With ``prefix="knee"`` and no suffix the keys
+        are ``knee_l`` and ``knee_r``. Both values equal
+        ``math.radians(degrees)``.
+
+    Example:
+        >>> angles = {
+        ...     **bilateral("hip", 90, suffix="flex"),
+        ...     **bilateral("knee", -45),
+        ... }
+        >>> sorted(angles)
+        ['hip_l_flex', 'hip_r_flex', 'knee_l', 'knee_r']
+    """
+    rad = math.radians(degrees)
+    if suffix:
+        left_key = f"{prefix}_l_{suffix}"
+        right_key = f"{prefix}_r_{suffix}"
+    else:
+        left_key = f"{prefix}_l"
+        right_key = f"{prefix}_r"
+    return {left_key: rad, right_key: rad}

--- a/src/drake_models/optimization/objectives/bench_press.py
+++ b/src/drake_models/optimization/objectives/bench_press.py
@@ -6,13 +6,12 @@ Bar path is j-curve; balance mode is supine (body supported by bench).
 
 from __future__ import annotations
 
-import math
-
 from drake_models.optimization.objectives import (
     BalanceMode,
     ExerciseObjective,
     ExercisePhase,
 )
+from drake_models.optimization.objectives._helpers import bilateral
 
 BENCH_PRESS = ExerciseObjective(
     exercise_name="bench_press",
@@ -23,10 +22,8 @@ BENCH_PRESS = ExerciseObjective(
             name="lockout_top",
             time_fraction=0.0,
             joint_angles={
-                "shoulder_l_flex": math.radians(90),
-                "shoulder_r_flex": math.radians(90),
-                "shoulder_l_abd": math.radians(75),
-                "shoulder_r_abd": math.radians(75),
+                **bilateral("shoulder", 90, suffix="flex"),
+                **bilateral("shoulder", 75, suffix="abd"),
                 "elbow_l": 0.0,
                 "elbow_r": 0.0,
             },
@@ -36,12 +33,9 @@ BENCH_PRESS = ExerciseObjective(
             name="chest_touch",
             time_fraction=0.5,
             joint_angles={
-                "shoulder_l_flex": math.radians(45),
-                "shoulder_r_flex": math.radians(45),
-                "shoulder_l_abd": math.radians(75),
-                "shoulder_r_abd": math.radians(75),
-                "elbow_l": math.radians(-90),
-                "elbow_r": math.radians(-90),
+                **bilateral("shoulder", 45, suffix="flex"),
+                **bilateral("shoulder", 75, suffix="abd"),
+                **bilateral("elbow", -90),
             },
             bar_height_fraction=0.0,
         ),
@@ -49,10 +43,8 @@ BENCH_PRESS = ExerciseObjective(
             name="lockout_finish",
             time_fraction=1.0,
             joint_angles={
-                "shoulder_l_flex": math.radians(90),
-                "shoulder_r_flex": math.radians(90),
-                "shoulder_l_abd": math.radians(75),
-                "shoulder_r_abd": math.radians(75),
+                **bilateral("shoulder", 90, suffix="flex"),
+                **bilateral("shoulder", 75, suffix="abd"),
                 "elbow_l": 0.0,
                 "elbow_r": 0.0,
             },

--- a/src/drake_models/optimization/objectives/clean_and_jerk.py
+++ b/src/drake_models/optimization/objectives/clean_and_jerk.py
@@ -6,13 +6,12 @@ Bar path is s-curve; balance mode is standing.
 
 from __future__ import annotations
 
-import math
-
 from drake_models.optimization.objectives import (
     BalanceMode,
     ExerciseObjective,
     ExercisePhase,
 )
+from drake_models.optimization.objectives._helpers import bilateral
 
 CLEAN_AND_JERK = ExerciseObjective(
     exercise_name="clean_and_jerk",
@@ -23,12 +22,9 @@ CLEAN_AND_JERK = ExerciseObjective(
             name="floor",
             time_fraction=0.0,
             joint_angles={
-                "hip_l_flex": math.radians(85),
-                "hip_r_flex": math.radians(85),
-                "knee_l": math.radians(-75),
-                "knee_r": math.radians(-75),
-                "shoulder_l_flex": math.radians(-10),
-                "shoulder_r_flex": math.radians(-10),
+                **bilateral("hip", 85, suffix="flex"),
+                **bilateral("knee", -75),
+                **bilateral("shoulder", -10, suffix="flex"),
                 "elbow_l": 0.0,
                 "elbow_r": 0.0,
             },
@@ -38,12 +34,9 @@ CLEAN_AND_JERK = ExerciseObjective(
             name="knee_pass",
             time_fraction=0.2,
             joint_angles={
-                "hip_l_flex": math.radians(55),
-                "hip_r_flex": math.radians(55),
-                "knee_l": math.radians(-25),
-                "knee_r": math.radians(-25),
-                "shoulder_l_flex": math.radians(0),
-                "shoulder_r_flex": math.radians(0),
+                **bilateral("hip", 55, suffix="flex"),
+                **bilateral("knee", -25),
+                **bilateral("shoulder", 0, suffix="flex"),
                 "elbow_l": 0.0,
                 "elbow_r": 0.0,
             },
@@ -53,14 +46,10 @@ CLEAN_AND_JERK = ExerciseObjective(
             name="rack_position",
             time_fraction=0.5,
             joint_angles={
-                "hip_l_flex": math.radians(90),
-                "hip_r_flex": math.radians(90),
-                "knee_l": math.radians(-100),
-                "knee_r": math.radians(-100),
-                "shoulder_l_flex": math.radians(80),
-                "shoulder_r_flex": math.radians(80),
-                "elbow_l": math.radians(120),
-                "elbow_r": math.radians(120),
+                **bilateral("hip", 90, suffix="flex"),
+                **bilateral("knee", -100),
+                **bilateral("shoulder", 80, suffix="flex"),
+                **bilateral("elbow", 120),
             },
             bar_height_fraction=0.6,
         ),
@@ -68,14 +57,10 @@ CLEAN_AND_JERK = ExerciseObjective(
             name="jerk_dip",
             time_fraction=0.7,
             joint_angles={
-                "hip_l_flex": math.radians(20),
-                "hip_r_flex": math.radians(20),
-                "knee_l": math.radians(-30),
-                "knee_r": math.radians(-30),
-                "shoulder_l_flex": math.radians(80),
-                "shoulder_r_flex": math.radians(80),
-                "elbow_l": math.radians(120),
-                "elbow_r": math.radians(120),
+                **bilateral("hip", 20, suffix="flex"),
+                **bilateral("knee", -30),
+                **bilateral("shoulder", 80, suffix="flex"),
+                **bilateral("elbow", 120),
             },
             bar_height_fraction=0.7,
         ),
@@ -83,12 +68,9 @@ CLEAN_AND_JERK = ExerciseObjective(
             name="overhead_lockout",
             time_fraction=1.0,
             joint_angles={
-                "hip_l_flex": math.radians(5),
-                "hip_r_flex": math.radians(5),
-                "knee_l": math.radians(-5),
-                "knee_r": math.radians(-5),
-                "shoulder_l_flex": math.radians(175),
-                "shoulder_r_flex": math.radians(175),
+                **bilateral("hip", 5, suffix="flex"),
+                **bilateral("knee", -5),
+                **bilateral("shoulder", 175, suffix="flex"),
                 "elbow_l": 0.0,
                 "elbow_r": 0.0,
             },

--- a/src/drake_models/optimization/objectives/deadlift.py
+++ b/src/drake_models/optimization/objectives/deadlift.py
@@ -6,13 +6,12 @@ Bar path is vertical; balance mode is standing.
 
 from __future__ import annotations
 
-import math
-
 from drake_models.optimization.objectives import (
     BalanceMode,
     ExerciseObjective,
     ExercisePhase,
 )
+from drake_models.optimization.objectives._helpers import bilateral
 
 DEADLIFT = ExerciseObjective(
     exercise_name="deadlift",
@@ -23,12 +22,9 @@ DEADLIFT = ExerciseObjective(
             name="setup",
             time_fraction=0.0,
             joint_angles={
-                "hip_l_flex": math.radians(80),
-                "hip_r_flex": math.radians(80),
-                "knee_l": math.radians(-70),
-                "knee_r": math.radians(-70),
-                "shoulder_l_flex": math.radians(-10),
-                "shoulder_r_flex": math.radians(-10),
+                **bilateral("hip", 80, suffix="flex"),
+                **bilateral("knee", -70),
+                **bilateral("shoulder", -10, suffix="flex"),
                 "elbow_l": 0.0,
                 "elbow_r": 0.0,
             },
@@ -38,12 +34,9 @@ DEADLIFT = ExerciseObjective(
             name="knee_pass",
             time_fraction=0.4,
             joint_angles={
-                "hip_l_flex": math.radians(60),
-                "hip_r_flex": math.radians(60),
-                "knee_l": math.radians(-25),
-                "knee_r": math.radians(-25),
-                "shoulder_l_flex": math.radians(-5),
-                "shoulder_r_flex": math.radians(-5),
+                **bilateral("hip", 60, suffix="flex"),
+                **bilateral("knee", -25),
+                **bilateral("shoulder", -5, suffix="flex"),
                 "elbow_l": 0.0,
                 "elbow_r": 0.0,
             },
@@ -53,12 +46,9 @@ DEADLIFT = ExerciseObjective(
             name="lockout",
             time_fraction=1.0,
             joint_angles={
-                "hip_l_flex": math.radians(0),
-                "hip_r_flex": math.radians(0),
-                "knee_l": math.radians(0),
-                "knee_r": math.radians(0),
-                "shoulder_l_flex": math.radians(0),
-                "shoulder_r_flex": math.radians(0),
+                **bilateral("hip", 0, suffix="flex"),
+                **bilateral("knee", 0),
+                **bilateral("shoulder", 0, suffix="flex"),
                 "elbow_l": 0.0,
                 "elbow_r": 0.0,
             },

--- a/src/drake_models/optimization/objectives/sit_to_stand.py
+++ b/src/drake_models/optimization/objectives/sit_to_stand.py
@@ -6,13 +6,12 @@ No bar path; balance mode is standing.
 
 from __future__ import annotations
 
-import math
-
 from drake_models.optimization.objectives import (
     BalanceMode,
     ExerciseObjective,
     ExercisePhase,
 )
+from drake_models.optimization.objectives._helpers import bilateral
 
 SIT_TO_STAND = ExerciseObjective(
     exercise_name="sit_to_stand",
@@ -23,72 +22,54 @@ SIT_TO_STAND = ExerciseObjective(
             name="seated",
             time_fraction=0.0,
             joint_angles={
-                "hip_l_flex": math.radians(90),
-                "hip_r_flex": math.radians(90),
-                "knee_l": math.radians(-90),
-                "knee_r": math.radians(-90),
-                "ankle_l_flex": math.radians(0),
-                "ankle_r_flex": math.radians(0),
+                **bilateral("hip", 90, suffix="flex"),
+                **bilateral("knee", -90),
+                **bilateral("ankle", 0, suffix="flex"),
             },
         ),
         ExercisePhase(
             name="forward_lean",
             time_fraction=0.20,
             joint_angles={
-                "hip_l_flex": math.radians(100),
-                "hip_r_flex": math.radians(100),
-                "knee_l": math.radians(-90),
-                "knee_r": math.radians(-90),
-                "ankle_l_flex": math.radians(15),
-                "ankle_r_flex": math.radians(15),
+                **bilateral("hip", 100, suffix="flex"),
+                **bilateral("knee", -90),
+                **bilateral("ankle", 15, suffix="flex"),
             },
         ),
         ExercisePhase(
             name="momentum",
             time_fraction=0.35,
             joint_angles={
-                "hip_l_flex": math.radians(80),
-                "hip_r_flex": math.radians(80),
-                "knee_l": math.radians(-85),
-                "knee_r": math.radians(-85),
-                "ankle_l_flex": math.radians(20),
-                "ankle_r_flex": math.radians(20),
+                **bilateral("hip", 80, suffix="flex"),
+                **bilateral("knee", -85),
+                **bilateral("ankle", 20, suffix="flex"),
             },
         ),
         ExercisePhase(
             name="seat_off",
             time_fraction=0.50,
             joint_angles={
-                "hip_l_flex": math.radians(60),
-                "hip_r_flex": math.radians(60),
-                "knee_l": math.radians(-75),
-                "knee_r": math.radians(-75),
-                "ankle_l_flex": math.radians(20),
-                "ankle_r_flex": math.radians(20),
+                **bilateral("hip", 60, suffix="flex"),
+                **bilateral("knee", -75),
+                **bilateral("ankle", 20, suffix="flex"),
             },
         ),
         ExercisePhase(
             name="rising",
             time_fraction=0.75,
             joint_angles={
-                "hip_l_flex": math.radians(30),
-                "hip_r_flex": math.radians(30),
-                "knee_l": math.radians(-40),
-                "knee_r": math.radians(-40),
-                "ankle_l_flex": math.radians(10),
-                "ankle_r_flex": math.radians(10),
+                **bilateral("hip", 30, suffix="flex"),
+                **bilateral("knee", -40),
+                **bilateral("ankle", 10, suffix="flex"),
             },
         ),
         ExercisePhase(
             name="standing",
             time_fraction=1.0,
             joint_angles={
-                "hip_l_flex": math.radians(5),
-                "hip_r_flex": math.radians(5),
-                "knee_l": math.radians(-5),
-                "knee_r": math.radians(-5),
-                "ankle_l_flex": math.radians(0),
-                "ankle_r_flex": math.radians(0),
+                **bilateral("hip", 5, suffix="flex"),
+                **bilateral("knee", -5),
+                **bilateral("ankle", 0, suffix="flex"),
             },
         ),
     ),

--- a/src/drake_models/optimization/objectives/snatch.py
+++ b/src/drake_models/optimization/objectives/snatch.py
@@ -6,13 +6,12 @@ Bar path is s-curve; balance mode is standing.
 
 from __future__ import annotations
 
-import math
-
 from drake_models.optimization.objectives import (
     BalanceMode,
     ExerciseObjective,
     ExercisePhase,
 )
+from drake_models.optimization.objectives._helpers import bilateral
 
 SNATCH = ExerciseObjective(
     exercise_name="snatch",
@@ -23,12 +22,9 @@ SNATCH = ExerciseObjective(
             name="floor",
             time_fraction=0.0,
             joint_angles={
-                "hip_l_flex": math.radians(90),
-                "hip_r_flex": math.radians(90),
-                "knee_l": math.radians(-80),
-                "knee_r": math.radians(-80),
-                "shoulder_l_flex": math.radians(-10),
-                "shoulder_r_flex": math.radians(-10),
+                **bilateral("hip", 90, suffix="flex"),
+                **bilateral("knee", -80),
+                **bilateral("shoulder", -10, suffix="flex"),
                 "elbow_l": 0.0,
                 "elbow_r": 0.0,
             },
@@ -38,12 +34,9 @@ SNATCH = ExerciseObjective(
             name="knee_pass",
             time_fraction=0.25,
             joint_angles={
-                "hip_l_flex": math.radians(55),
-                "hip_r_flex": math.radians(55),
-                "knee_l": math.radians(-30),
-                "knee_r": math.radians(-30),
-                "shoulder_l_flex": math.radians(0),
-                "shoulder_r_flex": math.radians(0),
+                **bilateral("hip", 55, suffix="flex"),
+                **bilateral("knee", -30),
+                **bilateral("shoulder", 0, suffix="flex"),
                 "elbow_l": 0.0,
                 "elbow_r": 0.0,
             },
@@ -53,12 +46,9 @@ SNATCH = ExerciseObjective(
             name="power_position",
             time_fraction=0.45,
             joint_angles={
-                "hip_l_flex": math.radians(20),
-                "hip_r_flex": math.radians(20),
-                "knee_l": math.radians(-30),
-                "knee_r": math.radians(-30),
-                "shoulder_l_flex": math.radians(30),
-                "shoulder_r_flex": math.radians(30),
+                **bilateral("hip", 20, suffix="flex"),
+                **bilateral("knee", -30),
+                **bilateral("shoulder", 30, suffix="flex"),
                 "elbow_l": 0.0,
                 "elbow_r": 0.0,
             },
@@ -68,12 +58,9 @@ SNATCH = ExerciseObjective(
             name="overhead_catch",
             time_fraction=0.75,
             joint_angles={
-                "hip_l_flex": math.radians(100),
-                "hip_r_flex": math.radians(100),
-                "knee_l": math.radians(-110),
-                "knee_r": math.radians(-110),
-                "shoulder_l_flex": math.radians(170),
-                "shoulder_r_flex": math.radians(170),
+                **bilateral("hip", 100, suffix="flex"),
+                **bilateral("knee", -110),
+                **bilateral("shoulder", 170, suffix="flex"),
                 "elbow_l": 0.0,
                 "elbow_r": 0.0,
             },
@@ -83,12 +70,9 @@ SNATCH = ExerciseObjective(
             name="standing",
             time_fraction=1.0,
             joint_angles={
-                "hip_l_flex": math.radians(5),
-                "hip_r_flex": math.radians(5),
-                "knee_l": math.radians(-5),
-                "knee_r": math.radians(-5),
-                "shoulder_l_flex": math.radians(175),
-                "shoulder_r_flex": math.radians(175),
+                **bilateral("hip", 5, suffix="flex"),
+                **bilateral("knee", -5),
+                **bilateral("shoulder", 175, suffix="flex"),
                 "elbow_l": 0.0,
                 "elbow_r": 0.0,
             },

--- a/src/drake_models/optimization/objectives/squat.py
+++ b/src/drake_models/optimization/objectives/squat.py
@@ -6,13 +6,12 @@ Bar path is vertical; balance mode is standing (CoM over both feet).
 
 from __future__ import annotations
 
-import math
-
 from drake_models.optimization.objectives import (
     BalanceMode,
     ExerciseObjective,
     ExercisePhase,
 )
+from drake_models.optimization.objectives._helpers import bilateral
 
 SQUAT = ExerciseObjective(
     exercise_name="back_squat",
@@ -23,12 +22,9 @@ SQUAT = ExerciseObjective(
             name="unrack",
             time_fraction=0.0,
             joint_angles={
-                "hip_l_flex": math.radians(5),
-                "hip_r_flex": math.radians(5),
-                "hip_l_rotate": math.radians(10),
-                "hip_r_rotate": math.radians(10),
-                "knee_l": math.radians(-5),
-                "knee_r": math.radians(-5),
+                **bilateral("hip", 5, suffix="flex"),
+                **bilateral("hip", 10, suffix="rotate"),
+                **bilateral("knee", -5),
             },
             bar_height_fraction=1.0,
         ),
@@ -36,14 +32,10 @@ SQUAT = ExerciseObjective(
             name="bottom",
             time_fraction=0.45,
             joint_angles={
-                "hip_l_flex": math.radians(110),
-                "hip_r_flex": math.radians(110),
-                "hip_l_rotate": math.radians(15),
-                "hip_r_rotate": math.radians(15),
-                "knee_l": math.radians(-120),
-                "knee_r": math.radians(-120),
-                "ankle_l_flex": math.radians(25),
-                "ankle_r_flex": math.radians(25),
+                **bilateral("hip", 110, suffix="flex"),
+                **bilateral("hip", 15, suffix="rotate"),
+                **bilateral("knee", -120),
+                **bilateral("ankle", 25, suffix="flex"),
             },
             bar_height_fraction=0.55,
         ),
@@ -51,12 +43,9 @@ SQUAT = ExerciseObjective(
             name="lockout",
             time_fraction=1.0,
             joint_angles={
-                "hip_l_flex": math.radians(5),
-                "hip_r_flex": math.radians(5),
-                "hip_l_rotate": math.radians(10),
-                "hip_r_rotate": math.radians(10),
-                "knee_l": math.radians(-5),
-                "knee_r": math.radians(-5),
+                **bilateral("hip", 5, suffix="flex"),
+                **bilateral("hip", 10, suffix="rotate"),
+                **bilateral("knee", -5),
             },
             bar_height_fraction=1.0,
         ),

--- a/tests/unit/optimization/test_bilateral_helper.py
+++ b/tests/unit/optimization/test_bilateral_helper.py
@@ -1,0 +1,76 @@
+"""Tests for the bilateral joint-angle helper used by exercise objectives."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from drake_models.optimization.objectives._helpers import bilateral
+
+
+class TestBilateral:
+    """Behavioural checks for :func:`bilateral`.
+
+    The helper must produce numerically identical radian values to a direct
+    ``math.radians`` call so that refactored objective modules stay
+    byte-for-byte equivalent to the hand-written phase tables.
+    """
+
+    def test_positive_degrees_with_suffix(self) -> None:
+        result = bilateral("hip", 90, suffix="flex")
+        expected = math.radians(90)
+        assert result == {"hip_l_flex": expected, "hip_r_flex": expected}
+        # Left and right must be numerically identical (not mirrored).
+        assert result["hip_l_flex"] == result["hip_r_flex"]
+
+    def test_negative_degrees_with_suffix(self) -> None:
+        result = bilateral("shoulder", -10, suffix="flex")
+        expected = math.radians(-10)
+        assert result == {
+            "shoulder_l_flex": expected,
+            "shoulder_r_flex": expected,
+        }
+
+    def test_without_suffix(self) -> None:
+        result = bilateral("knee", -45)
+        expected = math.radians(-45)
+        assert result == {"knee_l": expected, "knee_r": expected}
+
+    def test_zero_degrees(self) -> None:
+        result = bilateral("knee", 0)
+        assert result == {"knee_l": 0.0, "knee_r": 0.0}
+
+    def test_returns_fresh_dict_each_call(self) -> None:
+        a = bilateral("hip", 90, suffix="flex")
+        b = bilateral("hip", 90, suffix="flex")
+        assert a == b
+        assert a is not b
+        a["hip_l_flex"] = 999.0
+        assert b["hip_l_flex"] == math.radians(90)
+
+    @pytest.mark.parametrize(
+        ("prefix", "degrees", "suffix"),
+        [
+            ("hip", 110, "flex"),
+            ("hip", 15, "rotate"),
+            ("knee", -120, ""),
+            ("ankle", 25, "flex"),
+            ("shoulder", 75, "abd"),
+            ("elbow", -90, ""),
+        ],
+    )
+    def test_numerically_identical_to_math_radians(
+        self, prefix: str, degrees: float, suffix: str
+    ) -> None:
+        """Refactor must be a no-op at the float-bit level."""
+        result = bilateral(prefix, degrees, suffix=suffix)
+        expected = math.radians(degrees)
+        if suffix:
+            left_key = f"{prefix}_l_{suffix}"
+            right_key = f"{prefix}_r_{suffix}"
+        else:
+            left_key = f"{prefix}_l"
+            right_key = f"{prefix}_r"
+        assert result[left_key] == expected
+        assert result[right_key] == expected


### PR DESCRIPTION
## Summary
- Adds a private `bilateral()` helper at `src/drake_models/optimization/objectives/_helpers.py` that returns a symmetric `{prefix}_l[_suffix]`/`{prefix}_r[_suffix]` radian dict from a single degree value.
- Applies it to the six symmetric exercise objective modules (squat, bench_press, deadlift, snatch, clean_and_jerk, sit_to_stand) to eliminate the repeated `math.radians()` double-entry pattern called out in #123.
- Gait is intentionally untouched because its phases use asymmetric left/right targets by design.
- Values are numerically identical to the previous hand-written entries; a new parametrized unit test locks that in.

Fixes #123

## Test plan
- [x] `python3 -m ruff check .`
- [x] `python3 -m ruff format --check .`
- [x] `python3 -m mypy src`
- [x] `python3 -m pytest tests/unit/optimization/`
- [ ] CI: ruff check, ruff format, mypy, pytest (>=80% coverage) across Python 3.10/3.11/3.12

Generated with Claude Code