### PR TITLE
refactor: extract build_exercise_model factory (DRY)

### DIFF
--- a/src/drake_models/exercises/bench_press/bench_press_model.py
+++ b/src/drake_models/exercises/bench_press/bench_press_model.py
@@ -21,9 +21,8 @@ import logging
 import math
 import xml.etree.ElementTree as ET
 
-from drake_models.exercises.base import ExerciseConfig, ExerciseModelBuilder
-from drake_models.shared.barbell import BarbellSpec
-from drake_models.shared.body import BodyModelSpec
+from drake_models.exercises.base import ExerciseModelBuilder
+from drake_models.exercises.factory import build_exercise_model
 from drake_models.shared.utils.geometry import rectangular_prism_inertia
 from drake_models.shared.utils.sdf_helpers import (
     add_contact_geometry,
@@ -206,8 +205,9 @@ def build_bench_press_model(
     plate_mass_per_side: float = 50.0,
 ) -> str:
     """Convenience function to build a bench press model SDF string."""
-    config = ExerciseConfig(
-        body_spec=BodyModelSpec(total_mass=body_mass, height=height),
-        barbell_spec=BarbellSpec.mens_olympic(plate_mass_per_side=plate_mass_per_side),
+    return build_exercise_model(
+        BenchPressModelBuilder,
+        body_mass=body_mass,
+        height=height,
+        plate_mass_per_side=plate_mass_per_side,
     )
-    return BenchPressModelBuilder(config).build()

--- a/src/drake_models/exercises/clean_and_jerk/clean_and_jerk_model.py
+++ b/src/drake_models/exercises/clean_and_jerk/clean_and_jerk_model.py
@@ -32,9 +32,8 @@ import logging
 import math
 import xml.etree.ElementTree as ET
 
-from drake_models.exercises.base import ExerciseConfig, ExerciseModelBuilder
-from drake_models.shared.barbell import BarbellSpec
-from drake_models.shared.body import BodyModelSpec
+from drake_models.exercises.base import ExerciseModelBuilder
+from drake_models.exercises.factory import build_exercise_model
 
 logger = logging.getLogger(__name__)
 
@@ -106,8 +105,9 @@ def build_clean_and_jerk_model(
 
     Default: 80 kg person, 120 kg total barbell.
     """
-    config = ExerciseConfig(
-        body_spec=BodyModelSpec(total_mass=body_mass, height=height),
-        barbell_spec=BarbellSpec.mens_olympic(plate_mass_per_side=plate_mass_per_side),
+    return build_exercise_model(
+        CleanAndJerkModelBuilder,
+        body_mass=body_mass,
+        height=height,
+        plate_mass_per_side=plate_mass_per_side,
     )
-    return CleanAndJerkModelBuilder(config).build()

--- a/src/drake_models/exercises/deadlift/deadlift_model.py
+++ b/src/drake_models/exercises/deadlift/deadlift_model.py
@@ -22,9 +22,8 @@ import logging
 import math
 import xml.etree.ElementTree as ET
 
-from drake_models.exercises.base import ExerciseConfig, ExerciseModelBuilder
-from drake_models.shared.barbell import BarbellSpec
-from drake_models.shared.body import BodyModelSpec
+from drake_models.exercises.base import ExerciseModelBuilder
+from drake_models.exercises.factory import build_exercise_model
 
 logger = logging.getLogger(__name__)
 
@@ -90,8 +89,9 @@ def build_deadlift_model(
     plate_mass_per_side: float = 80.0,
 ) -> str:
     """Convenience function to build a deadlift model SDF string."""
-    config = ExerciseConfig(
-        body_spec=BodyModelSpec(total_mass=body_mass, height=height),
-        barbell_spec=BarbellSpec.mens_olympic(plate_mass_per_side=plate_mass_per_side),
+    return build_exercise_model(
+        DeadliftModelBuilder,
+        body_mass=body_mass,
+        height=height,
+        plate_mass_per_side=plate_mass_per_side,
     )
-    return DeadliftModelBuilder(config).build()

--- a/src/drake_models/exercises/factory.py
+++ b/src/drake_models/exercises/factory.py
@@ -1,0 +1,66 @@
+"""Generic factory for building exercise SDF models.
+
+DRY: The seven exercise modules (squat, deadlift, bench_press, snatch,
+clean_and_jerk, gait, sit_to_stand) each expose a thin ``build_*_model``
+convenience helper whose body is a near-identical 3-to-5 line sequence:
+construct an :class:`ExerciseConfig` from ``body_mass`` / ``height`` /
+``plate_mass_per_side``, instantiate the builder subclass, call ``.build()``.
+
+This module extracts that shared skeleton into one parameterized factory
+so each exercise wrapper reduces to a single call. The factory preserves
+identical numerical output — it is a pure refactor.
+"""
+
+from __future__ import annotations
+
+from drake_models.exercises.base import ExerciseConfig, ExerciseModelBuilder
+from drake_models.shared.barbell import BarbellSpec
+from drake_models.shared.body import BodyModelSpec
+
+
+def build_exercise_model(
+    builder_cls: type[ExerciseModelBuilder],
+    body_mass: float = 80.0,
+    height: float = 1.75,
+    plate_mass_per_side: float = 20.0,
+    *,
+    include_barbell: bool = True,
+) -> str:
+    """Build an exercise SDF model from a builder class and scalar parameters.
+
+    This is the generic implementation behind the per-exercise
+    ``build_*_model`` helpers. It constructs an :class:`ExerciseConfig`,
+    instantiates ``builder_cls`` with that config, and returns the SDF
+    XML string produced by ``.build()``.
+
+    Args:
+        builder_cls: Concrete :class:`ExerciseModelBuilder` subclass to
+            instantiate (e.g. ``SquatModelBuilder``).
+        body_mass: Total body mass in kilograms.
+        height: Body height in meters.
+        plate_mass_per_side: Mass of plates loaded on each side of the
+            barbell in kilograms. Ignored when ``include_barbell`` is
+            ``False`` (e.g. gait, sit-to-stand).
+        include_barbell: If ``True`` (default), pass a configured
+            :class:`BarbellSpec` to the config. If ``False``, use the
+            config default — useful for bodyweight-only exercises that
+            still accept ``plate_mass_per_side`` for CLI compatibility.
+
+    Returns:
+        SDF 1.8 XML string describing the full exercise model.
+
+    Preconditions:
+        ``body_mass > 0``, ``height > 0``, ``plate_mass_per_side >= 0``
+        (enforced downstream by :class:`BodyModelSpec` / :class:`BarbellSpec`).
+    """
+    body_spec = BodyModelSpec(total_mass=body_mass, height=height)
+    if include_barbell:
+        config = ExerciseConfig(
+            body_spec=body_spec,
+            barbell_spec=BarbellSpec.mens_olympic(
+                plate_mass_per_side=plate_mass_per_side,
+            ),
+        )
+    else:
+        config = ExerciseConfig(body_spec=body_spec)
+    return builder_cls(config).build()

--- a/src/drake_models/exercises/gait/gait_model.py
+++ b/src/drake_models/exercises/gait/gait_model.py
@@ -21,8 +21,8 @@ import logging
 import math
 import xml.etree.ElementTree as ET
 
-from drake_models.exercises.base import ExerciseConfig, ExerciseModelBuilder
-from drake_models.shared.body import BodyModelSpec
+from drake_models.exercises.base import ExerciseModelBuilder
+from drake_models.exercises.factory import build_exercise_model
 
 logger = logging.getLogger(__name__)
 
@@ -92,7 +92,10 @@ def build_gait_model(
     The ``plate_mass_per_side`` parameter is accepted for CLI compatibility
     but ignored (barbell is present in SDF but unattached to the body).
     """
-    config = ExerciseConfig(
-        body_spec=BodyModelSpec(total_mass=body_mass, height=height),
+    del plate_mass_per_side  # accepted for CLI compatibility, unused
+    return build_exercise_model(
+        GaitModelBuilder,
+        body_mass=body_mass,
+        height=height,
+        include_barbell=False,
     )
-    return GaitModelBuilder(config).build()

--- a/src/drake_models/exercises/sit_to_stand/sit_to_stand_model.py
+++ b/src/drake_models/exercises/sit_to_stand/sit_to_stand_model.py
@@ -23,8 +23,8 @@ import logging
 import math
 import xml.etree.ElementTree as ET
 
-from drake_models.exercises.base import ExerciseConfig, ExerciseModelBuilder
-from drake_models.shared.body import BodyModelSpec
+from drake_models.exercises.base import ExerciseModelBuilder
+from drake_models.exercises.factory import build_exercise_model
 from drake_models.shared.utils.geometry import rectangular_prism_inertia
 from drake_models.shared.utils.sdf_helpers import (
     add_contact_geometry,
@@ -182,7 +182,10 @@ def build_sit_to_stand_model(
     The ``plate_mass_per_side`` parameter is accepted for CLI compatibility
     but ignored (sit-to-stand is bodyweight only).
     """
-    config = ExerciseConfig(
-        body_spec=BodyModelSpec(total_mass=body_mass, height=height),
+    del plate_mass_per_side  # accepted for CLI compatibility, unused
+    return build_exercise_model(
+        SitToStandModelBuilder,
+        body_mass=body_mass,
+        height=height,
+        include_barbell=False,
     )
-    return SitToStandModelBuilder(config).build()

--- a/src/drake_models/exercises/snatch/snatch_model.py
+++ b/src/drake_models/exercises/snatch/snatch_model.py
@@ -28,9 +28,8 @@ import logging
 import math
 import xml.etree.ElementTree as ET
 
-from drake_models.exercises.base import ExerciseConfig, ExerciseModelBuilder
-from drake_models.shared.barbell import BarbellSpec
-from drake_models.shared.body import BodyModelSpec
+from drake_models.exercises.base import ExerciseModelBuilder
+from drake_models.exercises.factory import build_exercise_model
 
 logger = logging.getLogger(__name__)
 
@@ -105,8 +104,9 @@ def build_snatch_model(
 
     Default: 80 kg person, 100 kg total barbell (competitive 96 kg class).
     """
-    config = ExerciseConfig(
-        body_spec=BodyModelSpec(total_mass=body_mass, height=height),
-        barbell_spec=BarbellSpec.mens_olympic(plate_mass_per_side=plate_mass_per_side),
+    return build_exercise_model(
+        SnatchModelBuilder,
+        body_mass=body_mass,
+        height=height,
+        plate_mass_per_side=plate_mass_per_side,
     )
-    return SnatchModelBuilder(config).build()

--- a/src/drake_models/exercises/squat/squat_model.py
+++ b/src/drake_models/exercises/squat/squat_model.py
@@ -17,9 +17,8 @@ import logging
 import math
 import xml.etree.ElementTree as ET
 
-from drake_models.exercises.base import ExerciseConfig, ExerciseModelBuilder
-from drake_models.shared.barbell import BarbellSpec
-from drake_models.shared.body import BodyModelSpec
+from drake_models.exercises.base import ExerciseModelBuilder
+from drake_models.exercises.factory import build_exercise_model
 from drake_models.shared.utils.sdf_helpers import add_fixed_joint
 
 logger = logging.getLogger(__name__)
@@ -115,8 +114,9 @@ def build_squat_model(
     Default: 80 kg person, 1.75 m tall, 140 kg total barbell
     (20 kg bar + 60 kg per side).
     """
-    config = ExerciseConfig(
-        body_spec=BodyModelSpec(total_mass=body_mass, height=height),
-        barbell_spec=BarbellSpec.mens_olympic(plate_mass_per_side=plate_mass_per_side),
+    return build_exercise_model(
+        SquatModelBuilder,
+        body_mass=body_mass,
+        height=height,
+        plate_mass_per_side=plate_mass_per_side,
     )
-    return SquatModelBuilder(config).build()

--- a/tests/unit/exercises/test_factory.py
+++ b/tests/unit/exercises/test_factory.py
@@ -1,0 +1,141 @@
+"""Tests for the generic ``build_exercise_model`` factory.
+
+These tests pin two invariants of the refactor that extracted the
+per-exercise ``build_*_model`` convenience helpers into a shared
+:func:`build_exercise_model` factory:
+
+1. The factory produces byte-for-byte identical output to the
+   pre-refactor per-exercise implementation (parity with the same
+   ``ExerciseConfig`` / builder-class composition).
+2. The public ``build_*_model`` wrappers continue to return the same
+   SDF regardless of which exercise they cover (squat, deadlift,
+   bench-press with barbells; gait, sit-to-stand without).
+"""
+
+from __future__ import annotations
+
+from drake_models.exercises.base import ExerciseConfig
+from drake_models.exercises.bench_press.bench_press_model import (
+    BenchPressModelBuilder,
+)
+from drake_models.exercises.deadlift.deadlift_model import (
+    DeadliftModelBuilder,
+    build_deadlift_model,
+)
+from drake_models.exercises.factory import build_exercise_model
+from drake_models.exercises.gait.gait_model import (
+    GaitModelBuilder,
+    build_gait_model,
+)
+from drake_models.exercises.sit_to_stand.sit_to_stand_model import (
+    SitToStandModelBuilder,
+    build_sit_to_stand_model,
+)
+from drake_models.exercises.squat.squat_model import (
+    SquatModelBuilder,
+    build_squat_model,
+)
+from drake_models.shared.barbell import BarbellSpec
+from drake_models.shared.body import BodyModelSpec
+
+
+class TestBuildExerciseModelFactory:
+    """Parity checks for the extracted factory."""
+
+    def test_factory_squat_matches_public_wrapper(self) -> None:
+        """Factory output matches build_squat_model() for shared defaults."""
+        factory_xml = build_exercise_model(
+            SquatModelBuilder,
+            body_mass=80.0,
+            height=1.75,
+            plate_mass_per_side=60.0,
+        )
+        wrapper_xml = build_squat_model(
+            body_mass=80.0,
+            height=1.75,
+            plate_mass_per_side=60.0,
+        )
+        assert factory_xml == wrapper_xml
+
+    def test_factory_deadlift_matches_public_wrapper(self) -> None:
+        """Factory output matches build_deadlift_model() for shared defaults."""
+        factory_xml = build_exercise_model(
+            DeadliftModelBuilder,
+            body_mass=80.0,
+            height=1.75,
+            plate_mass_per_side=80.0,
+        )
+        wrapper_xml = build_deadlift_model(
+            body_mass=80.0,
+            height=1.75,
+            plate_mass_per_side=80.0,
+        )
+        assert factory_xml == wrapper_xml
+
+    def test_factory_matches_manual_config_squat(self) -> None:
+        """Factory matches hand-rolled ExerciseConfig + builder invocation."""
+        config = ExerciseConfig(
+            body_spec=BodyModelSpec(total_mass=75.0, height=1.80),
+            barbell_spec=BarbellSpec.mens_olympic(plate_mass_per_side=40.0),
+        )
+        manual_xml = SquatModelBuilder(config).build()
+        factory_xml = build_exercise_model(
+            SquatModelBuilder,
+            body_mass=75.0,
+            height=1.80,
+            plate_mass_per_side=40.0,
+        )
+        assert factory_xml == manual_xml
+
+    def test_factory_matches_manual_config_bench_press(self) -> None:
+        """Factory matches manual config for a second barbell exercise."""
+        config = ExerciseConfig(
+            body_spec=BodyModelSpec(total_mass=90.0, height=1.82),
+            barbell_spec=BarbellSpec.mens_olympic(plate_mass_per_side=55.0),
+        )
+        manual_xml = BenchPressModelBuilder(config).build()
+        factory_xml = build_exercise_model(
+            BenchPressModelBuilder,
+            body_mass=90.0,
+            height=1.82,
+            plate_mass_per_side=55.0,
+        )
+        assert factory_xml == manual_xml
+
+    def test_factory_bodyweight_gait_matches_wrapper(self) -> None:
+        """Bodyweight (``include_barbell=False``) parity for gait."""
+        factory_xml = build_exercise_model(
+            GaitModelBuilder,
+            body_mass=80.0,
+            height=1.75,
+            include_barbell=False,
+        )
+        wrapper_xml = build_gait_model(body_mass=80.0, height=1.75)
+        assert factory_xml == wrapper_xml
+
+    def test_factory_bodyweight_sit_to_stand_matches_wrapper(self) -> None:
+        """Bodyweight parity for sit-to-stand (second no-barbell exercise)."""
+        factory_xml = build_exercise_model(
+            SitToStandModelBuilder,
+            body_mass=80.0,
+            height=1.75,
+            include_barbell=False,
+        )
+        wrapper_xml = build_sit_to_stand_model(body_mass=80.0, height=1.75)
+        assert factory_xml == wrapper_xml
+
+    def test_factory_propagates_custom_body_params(self) -> None:
+        """Body mass and height flow through to the rendered SDF."""
+        xml_80kg = build_exercise_model(
+            SquatModelBuilder,
+            body_mass=80.0,
+            height=1.75,
+            plate_mass_per_side=20.0,
+        )
+        xml_100kg = build_exercise_model(
+            SquatModelBuilder,
+            body_mass=100.0,
+            height=1.75,
+            plate_mass_per_side=20.0,
+        )
+        assert xml_80kg != xml_100kg


### PR DESCRIPTION
## Summary
- Extract the shared skeleton of the seven per-exercise `build_*_model()` convenience helpers into a single `build_exercise_model(builder_cls, body_mass, height, plate_mass_per_side, *, include_barbell)` factory in `src/drake_models/exercises/factory.py`.
- Reduce each public `build_*_model()` wrapper to a single call to the factory. Public names (`build_squat_model`, `build_deadlift_model`, `build_bench_press_model`, `build_snatch_model`, `build_clean_and_jerk_model`, `build_gait_model`, `build_sit_to_stand_model`) keep their previous signatures and defaults, so all existing call sites in tests, CLI, and examples continue to work unchanged.
- Pure refactor: produces byte-for-byte identical SDF output (verified by new parity tests that compare factory output against both the public wrappers and hand-rolled `ExerciseConfig` + builder invocations).

Fixes #121

## Test plan
- [x] `python -m ruff check .` clean
- [x] `python -m ruff format --check .` clean
- [x] `python -m mypy src/drake_models/exercises/` clean
- [x] `python -m pytest tests/unit/exercises/` (136 passed)
- [x] `python -m pytest tests/integration/test_all_exercises_build.py` (90 passed, 1 pre-existing skip)
- [x] New `tests/unit/exercises/test_factory.py` pins factory/wrapper parity for squat, deadlift, bench-press, gait, and sit-to-stand (7 cases)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>