### PR TITLE
refactor: decompose _build_lumbar_joints and _add_3dof_joint_chain

### DIFF
--- a/src/drake_models/shared/body/body_model.py
+++ b/src/drake_models/shared/body/body_model.py
@@ -147,26 +147,25 @@ def _build_pelvis(
     return links
 
 
-def _build_lumbar_joints(
+def _create_lumbar_virtual_links(
+    model: ET.Element,
+) -> dict[str, ET.Element]:
+    """Create the two virtual links used by the lumbar compound joint chain."""
+    return {
+        "lumbar_virtual_1": add_virtual_link(model, name="lumbar_virtual_1"),
+        "lumbar_virtual_2": add_virtual_link(model, name="lumbar_virtual_2"),
+    }
+
+
+def _create_torso_link(
     model: ET.Element,
     spec: BodyModelSpec,
     t_len: float,
-) -> dict[str, ET.Element]:
-    """Create lumbar 3-DOF compound joints and the torso link.
-
-    Chain: pelvis -> lumbar_flex (X) -> v1 -> lumbar_lateral (Z)
-           -> v2 -> lumbar_rotate (Y) -> torso.
-
-    Returns dict containing torso, lumbar_virtual_1, lumbar_virtual_2.
-    """
-    links: dict[str, ET.Element] = {}
-    _p_mass, p_len, p_rad = _seg(spec, "pelvis")
+) -> ET.Element:
+    """Create the torso link sized from *spec* with box geometry."""
     t_mass, _t_len, t_rad = _seg(spec, "torso")
     t_inertia = rectangular_prism_inertia(t_mass, t_rad * 2, t_len, t_rad * 2)
-
-    links["lumbar_virtual_1"] = add_virtual_link(model, name="lumbar_virtual_1")
-    links["lumbar_virtual_2"] = add_virtual_link(model, name="lumbar_virtual_2")
-    links["torso"] = add_link(
+    return add_link(
         model,
         name="torso",
         mass=t_mass,
@@ -177,13 +176,21 @@ def _build_lumbar_joints(
         visual_geometry=make_box_geometry(t_rad * 2, t_rad * 2, t_len),
         collision_geometry=make_box_geometry(t_rad * 2, t_rad * 2, t_len),
     )
+
+
+def _wire_lumbar_joints(model: ET.Element, pelvis_length: float) -> None:
+    """Wire the three revolute joints that form the lumbar 3-DOF chain.
+
+    Chain: pelvis -> lumbar_flex (X) -> v1 -> lumbar_lateral (Z)
+           -> v2 -> lumbar_rotate (Y) -> torso.
+    """
     add_revolute_joint(
         model,
         name="lumbar_flex",
         parent="pelvis",
         child="lumbar_virtual_1",
         axis_xyz=(1, 0, 0),
-        pose=(0, 0, p_len / 2.0, 0, 0, 0),
+        pose=(0, 0, pelvis_length / 2.0, 0, 0, 0),
         lower_limit=LUMBAR_FLEX_LOWER,
         upper_limit=LUMBAR_FLEX_UPPER,
     )
@@ -207,6 +214,24 @@ def _build_lumbar_joints(
         lower_limit=LUMBAR_ROTATE_LOWER,
         upper_limit=LUMBAR_ROTATE_UPPER,
     )
+
+
+def _build_lumbar_joints(
+    model: ET.Element,
+    spec: BodyModelSpec,
+    t_len: float,
+) -> dict[str, ET.Element]:
+    """Create lumbar 3-DOF compound joints and the torso link.
+
+    Chain: pelvis -> lumbar_flex (X) -> v1 -> lumbar_lateral (Z)
+           -> v2 -> lumbar_rotate (Y) -> torso.
+
+    Returns dict containing torso, lumbar_virtual_1, lumbar_virtual_2.
+    """
+    _p_mass, p_len, _p_rad = _seg(spec, "pelvis")
+    links: dict[str, ET.Element] = _create_lumbar_virtual_links(model)
+    links["torso"] = _create_torso_link(model, spec, t_len)
+    _wire_lumbar_joints(model, p_len)
     return links
 
 

--- a/src/drake_models/shared/body/body_segments.py
+++ b/src/drake_models/shared/body/body_segments.py
@@ -120,6 +120,62 @@ def _add_bilateral_limb(
     return created
 
 
+def _create_3dof_virtual_links(
+    model: ET.Element,
+    *,
+    coord_prefix: str,
+    side: str,
+) -> tuple[str, str]:
+    """Create the two virtual links for a 3-DOF compound joint chain."""
+    v1_name = f"{coord_prefix}_{side}_virtual_1"
+    v2_name = f"{coord_prefix}_{side}_virtual_2"
+    add_virtual_link(model, name=v1_name)
+    add_virtual_link(model, name=v2_name)
+    return v1_name, v2_name
+
+
+def _add_adduct_joint(
+    model: ET.Element,
+    *,
+    name: str,
+    parent: str,
+    child: str,
+    limits: tuple[float, float],
+) -> None:
+    """Add the Z-axis (adduction/lateral) joint between two virtual links."""
+    add_revolute_joint(
+        model,
+        name=name,
+        parent=parent,
+        child=child,
+        axis_xyz=(0, 0, 1),
+        pose=(0, 0, 0, 0, 0, 0),
+        lower_limit=limits[0],
+        upper_limit=limits[1],
+    )
+
+
+def _add_rotate_joint(
+    model: ET.Element,
+    *,
+    name: str,
+    parent: str,
+    child: str,
+    limits: tuple[float, float],
+) -> None:
+    """Add the Y-axis (long-axis rotation) joint to the terminal child link."""
+    add_revolute_joint(
+        model,
+        name=name,
+        parent=parent,
+        child=child,
+        axis_xyz=(0, 1, 0),
+        pose=(0, 0, 0, 0, 0, 0),
+        lower_limit=limits[0],
+        upper_limit=limits[1],
+    )
+
+
 def _add_3dof_joint_chain(
     model: ET.Element,
     *,
@@ -143,10 +199,9 @@ def _add_3dof_joint_chain(
 
     Returns ``(v1_name, v2_name)`` of the two newly-created virtual links.
     """
-    v1_name = f"{coord_prefix}_{side}_virtual_1"
-    v2_name = f"{coord_prefix}_{side}_virtual_2"
-    add_virtual_link(model, name=v1_name)
-    add_virtual_link(model, name=v2_name)
+    v1_name, v2_name = _create_3dof_virtual_links(
+        model, coord_prefix=coord_prefix, side=side
+    )
     _add_flex_joint(
         model,
         f"{coord_prefix}_{side}_flex",
@@ -155,25 +210,19 @@ def _add_3dof_joint_chain(
         (0, sign * parent_lateral_y, parent_offset_z, 0, 0, 0),
         flex_limits,
     )
-    add_revolute_joint(
+    _add_adduct_joint(
         model,
         name=f"{coord_prefix}_{side}_{adduct_label}",
         parent=v1_name,
         child=v2_name,
-        axis_xyz=(0, 0, 1),
-        pose=(0, 0, 0, 0, 0, 0),
-        lower_limit=adduct_limits[0],
-        upper_limit=adduct_limits[1],
+        limits=adduct_limits,
     )
-    add_revolute_joint(
+    _add_rotate_joint(
         model,
         name=f"{coord_prefix}_{side}_{rotate_label}",
         parent=v2_name,
         child=link_name,
-        axis_xyz=(0, 1, 0),
-        pose=(0, 0, 0, 0, 0, 0),
-        lower_limit=rotate_limits[0],
-        upper_limit=rotate_limits[1],
+        limits=rotate_limits,
     )
     return v1_name, v2_name
 


### PR DESCRIPTION
## Summary
- Decomposes `_build_lumbar_joints` (61 LOC) into a 10-line orchestrator plus three focused helpers: `_create_lumbar_virtual_links`, `_create_torso_link`, `_wire_lumbar_joints`.
- Decomposes `_add_3dof_joint_chain` (56 LOC) into a shorter orchestrator plus helpers `_create_3dof_virtual_links`, `_add_adduct_joint`, `_add_rotate_joint`.
- Public names and signatures unchanged. State passed via arguments (no closures). SDF output is byte-identical.

Fixes #120

## Test plan
- [x] `ruff check .` clean
- [x] `ruff format --check .` clean
- [x] `mypy src/` clean
- [x] `pytest tests/unit/ -x` all pass

Generated with [Claude Code](https://claude.com/claude-code)