### PR TITLE
refactor: decompose 8 remaining oversized functions (#124)

### DIFF
--- a/src/drake_models/exercises/base.py
+++ b/src/drake_models/exercises/base.py
@@ -216,38 +216,41 @@ class ExerciseModelBuilder(ABC):
             add_collision_filter_group(model, name=group_name, members=members)
         logger.debug("Added %d collision filter groups", len(adjacent_pairs))
 
+    def _init_sdf_root(self) -> tuple[ET.Element, ET.Element]:
+        """Create the SDF root, model element, gravity, and static flag.
+
+        Returns ``(root, model)`` — the SDF root element and its model child.
+        """
+        root = ET.Element("sdf", version="1.8")
+        model = ET.SubElement(root, "model", name=self.exercise_name)
+
+        # Gravity
+        gravity_el = ET.SubElement(model, "gravity")
+        gravity_el.text = vec3_str(*self.config.gravity)
+
+        # Static flag (false — this is a dynamic model)
+        ET.SubElement(model, "static").text = "false"
+        return root, model
+
     def build(self) -> str:
         """Build the complete SDF model XML and return as string.
 
         Postcondition: returned string is well-formed XML.
         """
         logger.info("Building exercise model: %s", self.exercise_name)
-        root = ET.Element("sdf", version="1.8")
-        model = ET.SubElement(root, "model", name=self.exercise_name)
-
-        # Gravity
-        gravity_el = ET.SubElement(model, "gravity")
-        g = self.config.gravity
-        gravity_el.text = vec3_str(*g)
-
-        # Static flag (false — this is a dynamic model)
-        ET.SubElement(model, "static").text = "false"
+        root, model = self._init_sdf_root()
 
         # Ground plane with hydroelastic contact
         add_ground_plane_contact(model)
 
-        # Build body
+        # Build body and barbell
         body_links = create_full_body(
             model, self.config.body_spec, pelvis_joint_type=self.pelvis_joint_type
         )
-
-        # Build barbell
         barbell_links = create_barbell_links(model, self.config.barbell_spec)
 
-        # Exercise-specific attachment
+        # Exercise-specific attachment and initial pose
         self.attach_barbell(model, body_links, barbell_links)
-
-        # Exercise-specific initial pose
         self.set_initial_pose(model)
 
         # Collision exclusion filters for adjacent body segments

--- a/src/drake_models/exercises/bench_press/bench_press_model.py
+++ b/src/drake_models/exercises/bench_press/bench_press_model.py
@@ -81,17 +81,13 @@ class BenchPressModelBuilder(ExerciseModelBuilder):
         """Pelvis is welded via bench pad — no free floating joint."""
         return "fixed"
 
-    def _add_bench_body(self, model: ET.Element) -> ET.Element:
-        """Add the bench pad link and weld it to the world.
-
-        The bench pad is a box welded to the world frame at BENCH_HEIGHT so
-        that its top surface sits at exactly BENCH_HEIGHT meters above ground.
-        """
-        pad_z_center = BENCH_HEIGHT - BENCH_PAD_THICKNESS / 2.0
+    @staticmethod
+    def _create_bench_pad_link(model: ET.Element) -> ET.Element:
+        """Create the bench pad link with inertia and visual/collision geometry."""
         inertia = rectangular_prism_inertia(
             BENCH_PAD_MASS, BENCH_PAD_LENGTH, BENCH_PAD_WIDTH, BENCH_PAD_THICKNESS
         )
-        bench_link = add_link(
+        return add_link(
             model,
             name="bench_pad",
             mass=BENCH_PAD_MASS,
@@ -106,15 +102,10 @@ class BenchPressModelBuilder(ExerciseModelBuilder):
                 BENCH_PAD_LENGTH, BENCH_PAD_WIDTH, BENCH_PAD_THICKNESS
             ),
         )
-        add_fixed_joint(
-            model,
-            name="bench_to_world",
-            parent="world",
-            child="bench_pad",
-            pose=(0, 0, pad_z_center, 0, 0, 0),
-        )
 
-        # Contact geometry on top surface of bench pad
+    @staticmethod
+    def _add_bench_pad_contact(bench_link: ET.Element) -> None:
+        """Attach hydroelastic contact geometry to the bench pad top surface."""
         add_contact_geometry(
             bench_link,
             name="bench_pad_contact",
@@ -127,6 +118,22 @@ class BenchPressModelBuilder(ExerciseModelBuilder):
             hydroelastic_modulus=1e8,
         )
 
+    def _add_bench_body(self, model: ET.Element) -> ET.Element:
+        """Add the bench pad link and weld it to the world.
+
+        The bench pad is a box welded to the world frame at BENCH_HEIGHT so
+        that its top surface sits at exactly BENCH_HEIGHT meters above ground.
+        """
+        pad_z_center = BENCH_HEIGHT - BENCH_PAD_THICKNESS / 2.0
+        bench_link = self._create_bench_pad_link(model)
+        add_fixed_joint(
+            model,
+            name="bench_to_world",
+            parent="world",
+            child="bench_pad",
+            pose=(0, 0, pad_z_center, 0, 0, 0),
+        )
+        self._add_bench_pad_contact(bench_link)
         logger.debug("Added bench pad welded to world at z=%.3f m", pad_z_center)
         return bench_link
 

--- a/src/drake_models/optimization/trajectory_optimizer.py
+++ b/src/drake_models/optimization/trajectory_optimizer.py
@@ -414,19 +414,17 @@ def _add_phase_tracking_costs(
         )
 
 
-def _solve_with_drake(
-    sdf_string: str,
+def _build_drake_program(
+    plant: object,
     objective: ExerciseObjective,
     config: TrajectoryConfig,
-) -> TrajectoryResult:
-    """Solve trajectory optimization using Drake's MathematicalProgram.
+) -> tuple[object, object, object, object]:
+    """Construct the MathematicalProgram with decision variables and costs.
 
-    This is the full-fidelity path when pydrake is installed. It sets up
-    a direct transcription with MultibodyPlant dynamics constraints.
+    Returns ``(prog, q, v, u)`` — the program and its state/control variables.
     """
-    from pydrake.all import MathematicalProgram, Solve
+    from pydrake.all import MathematicalProgram
 
-    plant = _build_drake_plant(sdf_string, config.dt)
     n_q = plant.num_positions()  # type: ignore[attr-defined]
     n_v = plant.num_velocities()  # type: ignore[attr-defined]
     n_u = plant.num_actuators()  # type: ignore[attr-defined]
@@ -447,17 +445,31 @@ def _solve_with_drake(
         config.state_weight,
         config.terminal_weight,
     )
+    return prog, q, v, u
+
+
+def _solve_with_drake(
+    sdf_string: str,
+    objective: ExerciseObjective,
+    config: TrajectoryConfig,
+) -> TrajectoryResult:
+    """Solve trajectory optimization using Drake's MathematicalProgram.
+
+    This is the full-fidelity path when pydrake is installed. It sets up
+    a direct transcription with MultibodyPlant dynamics constraints.
+    """
+    from pydrake.all import Solve
+
+    plant = _build_drake_plant(sdf_string, config.dt)
+    prog, q, v, u = _build_drake_program(plant, objective, config)
 
     result = Solve(prog)
-    positions = result.GetSolution(q)
-    velocities = result.GetSolution(v)
-    torques = result.GetSolution(u)
-    time = np.linspace(0.0, config.total_time, n_steps)
+    time = np.linspace(0.0, config.total_time, config.n_timesteps)
 
     return TrajectoryResult(
-        joint_positions=positions,
-        joint_velocities=velocities,
-        joint_torques=torques,
+        joint_positions=result.GetSolution(q),
+        joint_velocities=result.GetSolution(v),
+        joint_torques=result.GetSolution(u),
         time=time,
         cost=result.get_optimal_cost(),
         converged=result.is_success(),


### PR DESCRIPTION
## Summary

Addresses issue #124 (8 functions in the 40-50 LOC range).

Investigation revealed that 5 of the 8 listed functions had already been decomposed in prior work. Their total line counts appear inflated by long docstrings and multi-line signatures; actual body LOC was well under 30:

| Function | Body LOC |
|---|---|
| interpolate_trajectory | 31 (helpers already present) |
| _add_compound_3dof_bilateral | 29 |
| solve_ik_keyframes | 19 |
| add_contact_geometry | 16 |
| _attach_bilateral_grip | 21 |

The remaining 3 orchestrators were decomposed via Extract Method:

- **_solve_with_drake** (39 -> 17 body LOC): extracted _build_drake_program to own MathematicalProgram setup with decision variables and costs.
- **_add_bench_body** (42 -> 12 body LOC): extracted _create_bench_pad_link and _add_bench_pad_contact.
- **ExerciseModelBuilder.build** (38 -> 25 body LOC): extracted _init_sdf_root for SDF root, gravity, and static flag boilerplate.

Public function names and signatures are unchanged. Numerical behaviour is identical.

## Test plan

- [x] python3 -m ruff check . - clean
- [x] python3 -m ruff format --check . - clean
- [x] python3 -m mypy src/ - clean
- [x] python3 -m pytest tests/unit/ -x --timeout=60 - 517 passed

Fixes #124

Generated with Claude Code