### PR TITLE
refactor: address #126 (oversized functions) and #127 (monolithic scripts)

### DIFF
--- a/scripts/setup_dev.py
+++ b/scripts/setup_dev.py
@@ -11,6 +11,47 @@ PROJECT_ROOT: Path = _SCRIPT_DIR.parent
 VENDOR_UD_TOOLS = PROJECT_ROOT / "vendor" / "ud-tools"
 
 
+def _require_python_version() -> None:
+    """Exit unless the running Python is at least ``MIN_PYTHON``."""
+    if sys.version_info < MIN_PYTHON:
+        sys.exit(f"Python {MIN_PYTHON[0]}.{MIN_PYTHON[1]}+ is required.")
+
+
+def _init_submodules() -> None:
+    """Initialise and update git submodules under ``PROJECT_ROOT``."""
+    print("[INFO] Initialising git submodules...")
+    subprocess.run(
+        ["git", "submodule", "update", "--init", "--recursive"],
+        cwd=PROJECT_ROOT,
+        check=True,
+    )
+
+
+def _install_project() -> None:
+    """Install the Drake_Models package (with dev extras) in editable mode."""
+    print("[INFO] Installing drake-models[dev] in editable mode...")
+    subprocess.run(
+        [sys.executable, "-m", "pip", "install", "-e", ".[dev]"],
+        cwd=PROJECT_ROOT,
+        check=True,
+    )
+
+
+def _install_vendor_ud_tools() -> None:
+    """Install the vendored ``ud-tools`` package in editable mode.
+
+    Exits with an error if ``vendor/ud-tools`` is missing.
+    """
+    if not VENDOR_UD_TOOLS.is_dir():
+        sys.exit(f"vendor/ud-tools not found at {VENDOR_UD_TOOLS}.")
+    print("[INFO] Installing vendor/ud-tools in editable mode...")
+    subprocess.run(
+        [sys.executable, "-m", "pip", "install", "-e", str(VENDOR_UD_TOOLS)],
+        cwd=PROJECT_ROOT,
+        check=True,
+    )
+
+
 def main() -> None:
     """Bootstrap the developer environment for Drake_Models.
 
@@ -21,33 +62,10 @@ def main() -> None:
         SystemExit: If the Python version is below the minimum or if
             vendor/ud-tools is not found.
     """
-    if sys.version_info < MIN_PYTHON:
-        sys.exit(f"Python {MIN_PYTHON[0]}.{MIN_PYTHON[1]}+ is required.")
-
-    print("[INFO] Initialising git submodules...")
-    subprocess.run(
-        ["git", "submodule", "update", "--init", "--recursive"],
-        cwd=PROJECT_ROOT,
-        check=True,
-    )
-
-    print("[INFO] Installing drake-models[dev] in editable mode...")
-    subprocess.run(
-        [sys.executable, "-m", "pip", "install", "-e", ".[dev]"],
-        cwd=PROJECT_ROOT,
-        check=True,
-    )
-
-    if not VENDOR_UD_TOOLS.is_dir():
-        sys.exit(f"vendor/ud-tools not found at {VENDOR_UD_TOOLS}.")
-
-    print("[INFO] Installing vendor/ud-tools in editable mode...")
-    subprocess.run(
-        [sys.executable, "-m", "pip", "install", "-e", str(VENDOR_UD_TOOLS)],
-        cwd=PROJECT_ROOT,
-        check=True,
-    )
-
+    _require_python_version()
+    _init_submodules()
+    _install_project()
+    _install_vendor_ud_tools()
     print("[ OK ] Development environment ready!")
 
 

--- a/src/drake_models/__main__.py
+++ b/src/drake_models/__main__.py
@@ -35,17 +35,17 @@ BUILDER_FUNCTIONS = {
 }
 
 
-def _build_arg_parser() -> argparse.ArgumentParser:
-    """Construct and return the CLI argument parser."""
-    parser = argparse.ArgumentParser(
-        prog="drake-models",
-        description="Generate Drake SDF models for barbell exercises.",
-    )
+def _add_exercise_argument(parser: argparse.ArgumentParser) -> None:
+    """Add the positional ``exercise`` argument to *parser*."""
     parser.add_argument(
         "exercise",
         choices=sorted(EXERCISES.keys()),
         help="Exercise to generate a model for.",
     )
+
+
+def _add_anthropometric_arguments(parser: argparse.ArgumentParser) -> None:
+    """Add body-mass, height, and plate-mass options to *parser*."""
     parser.add_argument(
         "--mass",
         type=float,
@@ -64,6 +64,10 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         default=60.0,
         help="Plate mass per side in kg (default: 60.0).",
     )
+
+
+def _add_output_arguments(parser: argparse.ArgumentParser) -> None:
+    """Add output-file and verbosity flags to *parser*."""
     parser.add_argument(
         "-o",
         "--output",
@@ -77,6 +81,17 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Enable verbose logging.",
     )
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    """Construct and return the CLI argument parser."""
+    parser = argparse.ArgumentParser(
+        prog="drake-models",
+        description="Generate Drake SDF models for barbell exercises.",
+    )
+    _add_exercise_argument(parser)
+    _add_anthropometric_arguments(parser)
+    _add_output_arguments(parser)
     return parser
 
 

--- a/src/drake_models/exercises/base.py
+++ b/src/drake_models/exercises/base.py
@@ -112,6 +112,43 @@ class ExerciseModelBuilder(ABC):
         return initial_pose
 
     @staticmethod
+    def _validate_grip_preconditions(
+        body_links: dict[str, ET.Element],
+        barbell_links: dict[str, ET.Element],
+    ) -> None:
+        """Raise ``ValueError`` when required hand or barbell links are absent.
+
+        Preconditions (DbC): ``'hand_l'`` and ``'hand_r'`` in *body_links*;
+        ``'barbell_shaft'`` in *barbell_links*.
+        """
+        if "hand_l" not in body_links:
+            raise ValueError("Body model missing required 'hand_l' link")
+        if "hand_r" not in body_links:
+            raise ValueError("Body model missing required 'hand_r' link")
+        if "barbell_shaft" not in barbell_links:
+            raise ValueError("Barbell model missing required 'barbell_shaft' link")
+
+    @staticmethod
+    def _weld_barbell_to_left_hand(
+        model: ET.Element,
+        grip_offset: float,
+    ) -> None:
+        """Add the single fixed joint welding ``barbell_shaft`` to ``hand_l``."""
+        from drake_models.shared.utils.sdf_helpers import add_fixed_joint
+
+        add_fixed_joint(
+            model,
+            name="barbell_to_left_hand",
+            parent="hand_l",
+            child="barbell_shaft",
+            pose=(0, -grip_offset, 0, 0, 0, 0),
+        )
+        logger.debug(
+            "Attached barbell to left hand at grip offset %.3f m (SDF tree-safe)",
+            grip_offset,
+        )
+
+    @staticmethod
     def _attach_bilateral_grip(
         model: ET.Element,
         body_links: dict[str, ET.Element],
@@ -135,38 +172,12 @@ class ExerciseModelBuilder(ABC):
         Preconditions: 'hand_l', 'hand_r' in body_links;
                        'barbell_shaft' in barbell_links.
         """
-        from drake_models.shared.utils.sdf_helpers import add_fixed_joint
-
-        if "hand_l" not in body_links:
-            raise ValueError("Body model missing required 'hand_l' link")
-        if "hand_r" not in body_links:
-            raise ValueError("Body model missing required 'hand_r' link")
-        if "barbell_shaft" not in barbell_links:
-            raise ValueError("Barbell model missing required 'barbell_shaft' link")
-
-        # barbell_shaft is a child of hand_l — valid single-parent attachment
-        add_fixed_joint(
-            model,
-            name="barbell_to_left_hand",
-            parent="hand_l",
-            child="barbell_shaft",
-            pose=(0, -grip_offset, 0, 0, 0, 0),
-        )
-        logger.debug(
-            "Attached barbell to left hand at grip offset %.3f m (SDF tree-safe)",
-            grip_offset,
-        )
+        ExerciseModelBuilder._validate_grip_preconditions(body_links, barbell_links)
+        ExerciseModelBuilder._weld_barbell_to_left_hand(model, grip_offset)
 
     @staticmethod
-    def _bilateral_collision_pairs(side: str) -> list[tuple[str, list[str]]]:
-        """Return collision filter group definitions for one body side.
-
-        Args:
-            side: ``'l'`` or ``'r'``.
-
-        Returns:
-            List of ``(group_name, [member_links])`` tuples for the given side.
-        """
+    def _lower_body_collision_pairs(side: str) -> list[tuple[str, list[str]]]:
+        """Return hip, knee, and ankle collision groups for one body side."""
         return [
             (
                 f"hip_{side}",
@@ -182,6 +193,12 @@ class ExerciseModelBuilder(ABC):
                 f"ankle_{side}",
                 [f"shank_{side}", f"foot_{side}", f"ankle_{side}_virtual_1"],
             ),
+        ]
+
+    @staticmethod
+    def _upper_body_collision_pairs(side: str) -> list[tuple[str, list[str]]]:
+        """Return shoulder, elbow, and wrist collision groups for one side."""
+        return [
             (
                 f"shoulder_{side}",
                 [
@@ -196,6 +213,21 @@ class ExerciseModelBuilder(ABC):
                 f"wrist_{side}",
                 [f"forearm_{side}", f"hand_{side}", f"wrist_{side}_virtual_1"],
             ),
+        ]
+
+    @staticmethod
+    def _bilateral_collision_pairs(side: str) -> list[tuple[str, list[str]]]:
+        """Return collision filter group definitions for one body side.
+
+        Args:
+            side: ``'l'`` or ``'r'``.
+
+        Returns:
+            List of ``(group_name, [member_links])`` tuples for the given side.
+        """
+        return [
+            *ExerciseModelBuilder._lower_body_collision_pairs(side),
+            *ExerciseModelBuilder._upper_body_collision_pairs(side),
         ]
 
     @staticmethod
@@ -232,6 +264,21 @@ class ExerciseModelBuilder(ABC):
         ET.SubElement(model, "static").text = "false"
         return root, model
 
+    def _build_body_and_barbell(
+        self,
+        model: ET.Element,
+    ) -> tuple[dict[str, ET.Element], dict[str, ET.Element]]:
+        """Append the ground plane, body, and barbell links to *model*.
+
+        Returns ``(body_links, barbell_links)``.
+        """
+        add_ground_plane_contact(model)
+        body_links = create_full_body(
+            model, self.config.body_spec, pelvis_joint_type=self.pelvis_joint_type
+        )
+        barbell_links = create_barbell_links(model, self.config.barbell_spec)
+        return body_links, barbell_links
+
     def build(self) -> str:
         """Build the complete SDF model XML and return as string.
 
@@ -239,26 +286,10 @@ class ExerciseModelBuilder(ABC):
         """
         logger.info("Building exercise model: %s", self.exercise_name)
         root, model = self._init_sdf_root()
-
-        # Ground plane with hydroelastic contact
-        add_ground_plane_contact(model)
-
-        # Build body and barbell
-        body_links = create_full_body(
-            model, self.config.body_spec, pelvis_joint_type=self.pelvis_joint_type
-        )
-        barbell_links = create_barbell_links(model, self.config.barbell_spec)
-
-        # Exercise-specific attachment and initial pose
+        body_links, barbell_links = self._build_body_and_barbell(model)
         self.attach_barbell(model, body_links, barbell_links)
         self.set_initial_pose(model)
-
-        # Collision exclusion filters for adjacent body segments
         self._add_collision_filters(model)
-
         xml_str = serialize_model(root)
-
-        # Postcondition: well-formed XML
-        ensure_valid_xml(xml_str)
-
+        ensure_valid_xml(xml_str)  # postcondition: well-formed XML
         return xml_str

--- a/src/drake_models/shared/body/body_limbs.py
+++ b/src/drake_models/shared/body/body_limbs.py
@@ -1,0 +1,228 @@
+"""Limb builders for the full-body model (upper/lower limbs + foot contacts).
+
+Extracted from :mod:`body_model` to keep the orchestration entry point
+under the 300 LOC module budget (issue #127). No behaviour changes.
+"""
+
+from __future__ import annotations
+
+import logging
+import xml.etree.ElementTree as ET
+
+from drake_models.shared.body.body_anthropometrics import (
+    ANKLE_FLEX_LOWER,
+    ANKLE_FLEX_UPPER,
+    ANKLE_INVERT_LOWER,
+    ANKLE_INVERT_UPPER,
+    ELBOW_FLEXION_LIMIT,
+    FOOT_CONTACT_HEIGHT,
+    FOOT_CONTACT_LENGTH,
+    FOOT_CONTACT_WIDTH,
+    HIP_ADDUCT_LOWER,
+    HIP_ADDUCT_UPPER,
+    HIP_FLEX_LOWER,
+    HIP_FLEX_UPPER,
+    HIP_LATERAL_MULTIPLIER,
+    HIP_ROTATE_LOWER,
+    HIP_ROTATE_UPPER,
+    KNEE_FLEXION_LIMIT,
+    SHOULDER_ADDUCT_LOWER,
+    SHOULDER_ADDUCT_UPPER,
+    SHOULDER_FLEX_LOWER,
+    SHOULDER_FLEX_UPPER,
+    SHOULDER_HEIGHT_FRACTION,
+    SHOULDER_LATERAL_MULTIPLIER,
+    SHOULDER_ROTATE_LOWER,
+    SHOULDER_ROTATE_UPPER,
+    WRIST_DEVIATE_LOWER,
+    WRIST_DEVIATE_UPPER,
+    WRIST_FLEX_LOWER,
+    WRIST_FLEX_UPPER,
+    BodyModelSpec,
+    _seg,
+)
+from drake_models.shared.body.body_segments import (
+    _add_bilateral_limb,
+    _add_compound_2dof_bilateral,
+    _add_compound_3dof_bilateral,
+)
+from drake_models.shared.utils.sdf_helpers import (
+    add_contact_geometry,
+    make_box_geometry,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _build_shoulders(
+    model: ET.Element,
+    spec: BodyModelSpec,
+    t_len: float,
+    t_rad: float,
+) -> dict[str, ET.Element]:
+    """Create bilateral 3-DOF shoulder joints and upper_arm links."""
+    return _add_compound_3dof_bilateral(
+        model,
+        spec,
+        seg_name="upper_arm",
+        parent_name="torso",
+        parent_offset_z=t_len * SHOULDER_HEIGHT_FRACTION,
+        parent_lateral_y=t_rad * SHOULDER_LATERAL_MULTIPLIER,
+        coord_prefix="shoulder",
+        flex_limits=(SHOULDER_FLEX_LOWER, SHOULDER_FLEX_UPPER),
+        adduct_limits=(SHOULDER_ADDUCT_LOWER, SHOULDER_ADDUCT_UPPER),
+        rotate_limits=(SHOULDER_ROTATE_LOWER, SHOULDER_ROTATE_UPPER),
+    )
+
+
+def _build_elbows(
+    model: ET.Element,
+    spec: BodyModelSpec,
+) -> dict[str, ET.Element]:
+    """Create bilateral 1-DOF elbow joints and forearm links."""
+    _ua_mass, ua_len, _ua_rad = _seg(spec, "upper_arm")
+    return _add_bilateral_limb(
+        model,
+        spec,
+        seg_name="forearm",
+        parent_name="upper_arm",
+        parent_offset_z=-ua_len,
+        parent_lateral_y=0,
+        coord_prefix="elbow",
+        range_min=0,
+        range_max=ELBOW_FLEXION_LIMIT,
+    )
+
+
+def _build_wrists(
+    model: ET.Element,
+    spec: BodyModelSpec,
+) -> dict[str, ET.Element]:
+    """Create bilateral 2-DOF wrist joints and hand links."""
+    _fa_mass, fa_len, _fa_rad = _seg(spec, "forearm")
+    return _add_compound_2dof_bilateral(
+        model,
+        spec,
+        seg_name="hand",
+        parent_name="forearm",
+        parent_offset_z=-fa_len,
+        parent_lateral_y=0,
+        coord_prefix="wrist",
+        flex_limits=(WRIST_FLEX_LOWER, WRIST_FLEX_UPPER),
+        second_limits=(WRIST_DEVIATE_LOWER, WRIST_DEVIATE_UPPER),
+        second_label="deviate",
+    )
+
+
+def _build_upper_limbs(
+    model: ET.Element,
+    spec: BodyModelSpec,
+) -> dict[str, ET.Element]:
+    """Stage 3: Create bilateral shoulders (3-DOF), elbows (1-DOF), wrists (2-DOF).
+
+    Returns dict with upper_arm, forearm, hand, and virtual link elements.
+    """
+    _t_mass, t_len, t_rad = _seg(spec, "torso")
+    links: dict[str, ET.Element] = {}
+    links.update(_build_shoulders(model, spec, t_len, t_rad))
+    links.update(_build_elbows(model, spec))
+    links.update(_build_wrists(model, spec))
+    return links
+
+
+def _build_hips(
+    model: ET.Element,
+    spec: BodyModelSpec,
+    p_len: float,
+    p_rad: float,
+) -> dict[str, ET.Element]:
+    """Create bilateral 3-DOF hip joints and thigh links."""
+    return _add_compound_3dof_bilateral(
+        model,
+        spec,
+        seg_name="thigh",
+        parent_name="pelvis",
+        parent_offset_z=-p_len / 2.0,
+        parent_lateral_y=p_rad * HIP_LATERAL_MULTIPLIER,
+        coord_prefix="hip",
+        flex_limits=(HIP_FLEX_LOWER, HIP_FLEX_UPPER),
+        adduct_limits=(HIP_ADDUCT_LOWER, HIP_ADDUCT_UPPER),
+        rotate_limits=(HIP_ROTATE_LOWER, HIP_ROTATE_UPPER),
+    )
+
+
+def _build_knees(
+    model: ET.Element,
+    spec: BodyModelSpec,
+) -> dict[str, ET.Element]:
+    """Create bilateral 1-DOF knee joints and shank links."""
+    _th_mass, th_len, _th_rad = _seg(spec, "thigh")
+    return _add_bilateral_limb(
+        model,
+        spec,
+        seg_name="shank",
+        parent_name="thigh",
+        parent_offset_z=-th_len,
+        parent_lateral_y=0,
+        coord_prefix="knee",
+        range_min=KNEE_FLEXION_LIMIT,
+        range_max=0,
+    )
+
+
+def _build_ankles(
+    model: ET.Element,
+    spec: BodyModelSpec,
+) -> dict[str, ET.Element]:
+    """Create bilateral 2-DOF ankle joints and foot links."""
+    _sh_mass, sh_len, _sh_rad = _seg(spec, "shank")
+    return _add_compound_2dof_bilateral(
+        model,
+        spec,
+        seg_name="foot",
+        parent_name="shank",
+        parent_offset_z=-sh_len,
+        parent_lateral_y=0,
+        coord_prefix="ankle",
+        flex_limits=(ANKLE_FLEX_LOWER, ANKLE_FLEX_UPPER),
+        second_limits=(ANKLE_INVERT_LOWER, ANKLE_INVERT_UPPER),
+        second_label="invert",
+    )
+
+
+def _build_lower_limbs(
+    model: ET.Element,
+    spec: BodyModelSpec,
+) -> dict[str, ET.Element]:
+    """Stage 4: Create bilateral hips (3-DOF), knees (1-DOF), ankles (2-DOF).
+
+    Returns dict with thigh, shank, foot, and virtual link elements.
+    """
+    _p_mass, p_len, p_rad = _seg(spec, "pelvis")
+    links: dict[str, ET.Element] = {}
+    links.update(_build_hips(model, spec, p_len, p_rad))
+    links.update(_build_knees(model, spec))
+    links.update(_build_ankles(model, spec))
+    return links
+
+
+def _build_foot_contacts(
+    model: ET.Element,
+    spec: BodyModelSpec,
+    links: dict[str, ET.Element],
+) -> None:
+    """Stage 5: Add foot sole hydroelastic contact geometry to both feet."""
+    _ft_mass, ft_len, _ft_rad = _seg(spec, "foot")
+    for side in ("l", "r"):
+        foot_link = links[f"foot_{side}"]
+        add_contact_geometry(
+            foot_link,
+            name=f"foot_{side}_contact",
+            geometry=make_box_geometry(
+                FOOT_CONTACT_LENGTH,
+                FOOT_CONTACT_WIDTH,
+                FOOT_CONTACT_HEIGHT,
+            ),
+            pose=(0, 0, -ft_len - FOOT_CONTACT_HEIGHT / 2.0, 0, 0, 0),
+        )
+    logger.debug("Added foot sole contact geometry (both sides)")

--- a/src/drake_models/shared/body/body_model.py
+++ b/src/drake_models/shared/body/body_model.py
@@ -33,7 +33,8 @@ link/joint elements -- they never manipulate segment internals.
 
 This module is an orchestration thin-layer.  Data lives in
 :mod:`body_anthropometrics`; low-level XML helpers live in
-:mod:`body_segments`.
+:mod:`body_segments`; trunk and limb staged builders live in
+:mod:`body_trunk` and :mod:`body_limbs` respectively.
 """
 
 from __future__ import annotations
@@ -42,420 +43,61 @@ import logging
 import xml.etree.ElementTree as ET
 
 from drake_models.shared.body.body_anthropometrics import (
-    ANKLE_FLEX_LOWER,
-    ANKLE_FLEX_UPPER,
-    ANKLE_INVERT_LOWER,
-    ANKLE_INVERT_UPPER,
-    ELBOW_FLEXION_LIMIT,
-    FOOT_CONTACT_HEIGHT,
-    FOOT_CONTACT_LENGTH,
-    FOOT_CONTACT_WIDTH,
-    HIP_ADDUCT_LOWER,
-    HIP_ADDUCT_UPPER,
-    HIP_FLEX_LOWER,
-    HIP_FLEX_UPPER,
-    HIP_LATERAL_MULTIPLIER,
-    HIP_ROTATE_LOWER,
-    HIP_ROTATE_UPPER,
-    KNEE_FLEXION_LIMIT,
-    LUMBAR_FLEX_LOWER,
-    LUMBAR_FLEX_UPPER,
-    LUMBAR_LATERAL_LOWER,
-    LUMBAR_LATERAL_UPPER,
-    LUMBAR_ROTATE_LOWER,
-    LUMBAR_ROTATE_UPPER,
-    NECK_RANGE_LIMIT,
-    PELVIS_STANDING_HEIGHT,
-    SHOULDER_ADDUCT_LOWER,
-    SHOULDER_ADDUCT_UPPER,
-    SHOULDER_FLEX_LOWER,
-    SHOULDER_FLEX_UPPER,
-    SHOULDER_HEIGHT_FRACTION,
-    SHOULDER_LATERAL_MULTIPLIER,
-    SHOULDER_ROTATE_LOWER,
-    SHOULDER_ROTATE_UPPER,
-    WRIST_DEVIATE_LOWER,
-    WRIST_DEVIATE_UPPER,
-    WRIST_FLEX_LOWER,
-    WRIST_FLEX_UPPER,
     BodyModelSpec,
-    _seg,
+    _seg,  # noqa: F401  # re-exported for API compatibility
+)
+
+# Stage builders are re-exported so callers and tests can keep importing
+# them from ``drake_models.shared.body.body_model``.
+from drake_models.shared.body.body_limbs import (
+    _build_ankles,
+    _build_elbows,
+    _build_foot_contacts,
+    _build_hips,
+    _build_knees,
+    _build_lower_limbs,
+    _build_shoulders,
+    _build_upper_limbs,
+    _build_wrists,
 )
 from drake_models.shared.body.body_segments import (
-    _add_bilateral_limb,
-    _add_compound_2dof_bilateral,
-    _add_compound_3dof_bilateral,
     _make_cylinder_segment_link,  # noqa: F401  # re-exported for API compatibility
 )
-from drake_models.shared.utils.geometry import (
-    cylinder_inertia,
-    rectangular_prism_inertia,
-)
-from drake_models.shared.utils.sdf_helpers import (
-    add_contact_geometry,
-    add_floating_joint,
-    add_link,
-    add_revolute_joint,
-    add_virtual_link,
-    make_box_geometry,
-    make_cylinder_geometry,
+from drake_models.shared.body.body_trunk import (
+    _build_head_link,
+    _build_lumbar_joints,
+    _build_pelvis,
+    _build_spine_and_head,
+    _create_lumbar_virtual_links,
+    _create_torso_link,
+    _wire_lumbar_joints,
 )
 
 logger = logging.getLogger(__name__)
 
-
-# ---------------------------------------------------------------------------
-# Staged builder methods for create_full_body (issue #77)
-# ---------------------------------------------------------------------------
-
-
-def _build_pelvis(
-    model: ET.Element,
-    spec: BodyModelSpec,
-    pelvis_joint_type: str,
-) -> dict[str, ET.Element]:
-    """Stage 1: Create pelvis link and optional world joint.
-
-    Returns dict with the 'pelvis' link element.
-    """
-    links: dict[str, ET.Element] = {}
-    p_mass, p_len, p_rad = _seg(spec, "pelvis")
-    p_inertia = rectangular_prism_inertia(p_mass, p_rad * 2, p_len, p_rad * 2)
-    links["pelvis"] = add_link(
-        model,
-        name="pelvis",
-        mass=p_mass,
-        mass_center=(0, 0, 0),
-        inertia_xx=p_inertia[0],
-        inertia_yy=p_inertia[1],
-        inertia_zz=p_inertia[2],
-        visual_geometry=make_box_geometry(p_rad * 2, p_rad * 2, p_len),
-        collision_geometry=make_box_geometry(p_rad * 2, p_rad * 2, p_len),
-    )
-    if pelvis_joint_type == "fixed":
-        logger.debug(
-            "Skipping world->pelvis joint; exercise builder will weld pelvis externally"
-        )
-    else:
-        add_floating_joint(
-            model,
-            name="ground_pelvis",
-            parent="world",
-            child="pelvis",
-            pose=(0, 0, PELVIS_STANDING_HEIGHT, 0, 0, 0),
-        )
-    return links
-
-
-def _create_lumbar_virtual_links(
-    model: ET.Element,
-) -> dict[str, ET.Element]:
-    """Create the two virtual links used by the lumbar compound joint chain."""
-    return {
-        "lumbar_virtual_1": add_virtual_link(model, name="lumbar_virtual_1"),
-        "lumbar_virtual_2": add_virtual_link(model, name="lumbar_virtual_2"),
-    }
-
-
-def _create_torso_link(
-    model: ET.Element,
-    spec: BodyModelSpec,
-    t_len: float,
-) -> ET.Element:
-    """Create the torso link sized from *spec* with box geometry."""
-    t_mass, _t_len, t_rad = _seg(spec, "torso")
-    t_inertia = rectangular_prism_inertia(t_mass, t_rad * 2, t_len, t_rad * 2)
-    return add_link(
-        model,
-        name="torso",
-        mass=t_mass,
-        mass_center=(0, 0, t_len / 2.0),
-        inertia_xx=t_inertia[0],
-        inertia_yy=t_inertia[1],
-        inertia_zz=t_inertia[2],
-        visual_geometry=make_box_geometry(t_rad * 2, t_rad * 2, t_len),
-        collision_geometry=make_box_geometry(t_rad * 2, t_rad * 2, t_len),
-    )
-
-
-def _wire_lumbar_joints(model: ET.Element, pelvis_length: float) -> None:
-    """Wire the three revolute joints that form the lumbar 3-DOF chain.
-
-    Chain: pelvis -> lumbar_flex (X) -> v1 -> lumbar_lateral (Z)
-           -> v2 -> lumbar_rotate (Y) -> torso.
-    """
-    add_revolute_joint(
-        model,
-        name="lumbar_flex",
-        parent="pelvis",
-        child="lumbar_virtual_1",
-        axis_xyz=(1, 0, 0),
-        pose=(0, 0, pelvis_length / 2.0, 0, 0, 0),
-        lower_limit=LUMBAR_FLEX_LOWER,
-        upper_limit=LUMBAR_FLEX_UPPER,
-    )
-    add_revolute_joint(
-        model,
-        name="lumbar_lateral",
-        parent="lumbar_virtual_1",
-        child="lumbar_virtual_2",
-        axis_xyz=(0, 0, 1),
-        pose=(0, 0, 0, 0, 0, 0),
-        lower_limit=LUMBAR_LATERAL_LOWER,
-        upper_limit=LUMBAR_LATERAL_UPPER,
-    )
-    add_revolute_joint(
-        model,
-        name="lumbar_rotate",
-        parent="lumbar_virtual_2",
-        child="torso",
-        axis_xyz=(0, 1, 0),
-        pose=(0, 0, 0, 0, 0, 0),
-        lower_limit=LUMBAR_ROTATE_LOWER,
-        upper_limit=LUMBAR_ROTATE_UPPER,
-    )
-
-
-def _build_lumbar_joints(
-    model: ET.Element,
-    spec: BodyModelSpec,
-    t_len: float,
-) -> dict[str, ET.Element]:
-    """Create lumbar 3-DOF compound joints and the torso link.
-
-    Chain: pelvis -> lumbar_flex (X) -> v1 -> lumbar_lateral (Z)
-           -> v2 -> lumbar_rotate (Y) -> torso.
-
-    Returns dict containing torso, lumbar_virtual_1, lumbar_virtual_2.
-    """
-    _p_mass, p_len, _p_rad = _seg(spec, "pelvis")
-    links: dict[str, ET.Element] = _create_lumbar_virtual_links(model)
-    links["torso"] = _create_torso_link(model, spec, t_len)
-    _wire_lumbar_joints(model, p_len)
-    return links
-
-
-def _build_head_link(
-    model: ET.Element,
-    spec: BodyModelSpec,
-    t_len: float,
-) -> dict[str, ET.Element]:
-    """Create the head link and neck revolute joint.
-
-    Returns dict containing the head link element.
-    """
-    h_mass, h_len, h_rad = _seg(spec, "head")
-    h_inertia = cylinder_inertia(h_mass, h_rad, h_len)
-    head_link = add_link(
-        model,
-        name="head",
-        mass=h_mass,
-        mass_center=(0, 0, h_len / 2.0),
-        inertia_xx=h_inertia[0],
-        inertia_yy=h_inertia[1],
-        inertia_zz=h_inertia[2],
-        visual_geometry=make_cylinder_geometry(h_rad, h_len),
-        collision_geometry=make_cylinder_geometry(h_rad, h_len),
-    )
-    add_revolute_joint(
-        model,
-        name="neck",
-        parent="torso",
-        child="head",
-        axis_xyz=(1, 0, 0),
-        pose=(0, 0, t_len, 0, 0, 0),
-        lower_limit=-NECK_RANGE_LIMIT,
-        upper_limit=NECK_RANGE_LIMIT,
-    )
-    return {"head": head_link}
-
-
-def _build_spine_and_head(
-    model: ET.Element,
-    spec: BodyModelSpec,
-) -> dict[str, ET.Element]:
-    """Stage 2: Create lumbar 3-DOF compound joint, torso, neck, and head.
-
-    Returns dict with torso, head, and lumbar virtual link elements.
-    """
-    _t_mass, t_len, _t_rad = _seg(spec, "torso")
-    links = _build_lumbar_joints(model, spec, t_len)
-    links.update(_build_head_link(model, spec, t_len))
-    return links
-
-
-def _build_shoulders(
-    model: ET.Element,
-    spec: BodyModelSpec,
-    t_len: float,
-    t_rad: float,
-) -> dict[str, ET.Element]:
-    """Create bilateral 3-DOF shoulder joints and upper_arm links."""
-    return _add_compound_3dof_bilateral(
-        model,
-        spec,
-        seg_name="upper_arm",
-        parent_name="torso",
-        parent_offset_z=t_len * SHOULDER_HEIGHT_FRACTION,
-        parent_lateral_y=t_rad * SHOULDER_LATERAL_MULTIPLIER,
-        coord_prefix="shoulder",
-        flex_limits=(SHOULDER_FLEX_LOWER, SHOULDER_FLEX_UPPER),
-        adduct_limits=(SHOULDER_ADDUCT_LOWER, SHOULDER_ADDUCT_UPPER),
-        rotate_limits=(SHOULDER_ROTATE_LOWER, SHOULDER_ROTATE_UPPER),
-    )
-
-
-def _build_elbows(
-    model: ET.Element,
-    spec: BodyModelSpec,
-) -> dict[str, ET.Element]:
-    """Create bilateral 1-DOF elbow joints and forearm links."""
-    _ua_mass, ua_len, _ua_rad = _seg(spec, "upper_arm")
-    return _add_bilateral_limb(
-        model,
-        spec,
-        seg_name="forearm",
-        parent_name="upper_arm",
-        parent_offset_z=-ua_len,
-        parent_lateral_y=0,
-        coord_prefix="elbow",
-        range_min=0,
-        range_max=ELBOW_FLEXION_LIMIT,
-    )
-
-
-def _build_wrists(
-    model: ET.Element,
-    spec: BodyModelSpec,
-) -> dict[str, ET.Element]:
-    """Create bilateral 2-DOF wrist joints and hand links."""
-    _fa_mass, fa_len, _fa_rad = _seg(spec, "forearm")
-    return _add_compound_2dof_bilateral(
-        model,
-        spec,
-        seg_name="hand",
-        parent_name="forearm",
-        parent_offset_z=-fa_len,
-        parent_lateral_y=0,
-        coord_prefix="wrist",
-        flex_limits=(WRIST_FLEX_LOWER, WRIST_FLEX_UPPER),
-        second_limits=(WRIST_DEVIATE_LOWER, WRIST_DEVIATE_UPPER),
-        second_label="deviate",
-    )
-
-
-def _build_upper_limbs(
-    model: ET.Element,
-    spec: BodyModelSpec,
-) -> dict[str, ET.Element]:
-    """Stage 3: Create bilateral shoulders (3-DOF), elbows (1-DOF), wrists (2-DOF).
-
-    Returns dict with upper_arm, forearm, hand, and virtual link elements.
-    """
-    _t_mass, t_len, t_rad = _seg(spec, "torso")
-    links: dict[str, ET.Element] = {}
-    links.update(_build_shoulders(model, spec, t_len, t_rad))
-    links.update(_build_elbows(model, spec))
-    links.update(_build_wrists(model, spec))
-    return links
-
-
-def _build_hips(
-    model: ET.Element,
-    spec: BodyModelSpec,
-    p_len: float,
-    p_rad: float,
-) -> dict[str, ET.Element]:
-    """Create bilateral 3-DOF hip joints and thigh links."""
-    return _add_compound_3dof_bilateral(
-        model,
-        spec,
-        seg_name="thigh",
-        parent_name="pelvis",
-        parent_offset_z=-p_len / 2.0,
-        parent_lateral_y=p_rad * HIP_LATERAL_MULTIPLIER,
-        coord_prefix="hip",
-        flex_limits=(HIP_FLEX_LOWER, HIP_FLEX_UPPER),
-        adduct_limits=(HIP_ADDUCT_LOWER, HIP_ADDUCT_UPPER),
-        rotate_limits=(HIP_ROTATE_LOWER, HIP_ROTATE_UPPER),
-    )
-
-
-def _build_knees(
-    model: ET.Element,
-    spec: BodyModelSpec,
-) -> dict[str, ET.Element]:
-    """Create bilateral 1-DOF knee joints and shank links."""
-    _th_mass, th_len, _th_rad = _seg(spec, "thigh")
-    return _add_bilateral_limb(
-        model,
-        spec,
-        seg_name="shank",
-        parent_name="thigh",
-        parent_offset_z=-th_len,
-        parent_lateral_y=0,
-        coord_prefix="knee",
-        range_min=KNEE_FLEXION_LIMIT,
-        range_max=0,
-    )
-
-
-def _build_ankles(
-    model: ET.Element,
-    spec: BodyModelSpec,
-) -> dict[str, ET.Element]:
-    """Create bilateral 2-DOF ankle joints and foot links."""
-    _sh_mass, sh_len, _sh_rad = _seg(spec, "shank")
-    return _add_compound_2dof_bilateral(
-        model,
-        spec,
-        seg_name="foot",
-        parent_name="shank",
-        parent_offset_z=-sh_len,
-        parent_lateral_y=0,
-        coord_prefix="ankle",
-        flex_limits=(ANKLE_FLEX_LOWER, ANKLE_FLEX_UPPER),
-        second_limits=(ANKLE_INVERT_LOWER, ANKLE_INVERT_UPPER),
-        second_label="invert",
-    )
-
-
-def _build_lower_limbs(
-    model: ET.Element,
-    spec: BodyModelSpec,
-) -> dict[str, ET.Element]:
-    """Stage 4: Create bilateral hips (3-DOF), knees (1-DOF), ankles (2-DOF).
-
-    Returns dict with thigh, shank, foot, and virtual link elements.
-    """
-    _p_mass, p_len, p_rad = _seg(spec, "pelvis")
-    links: dict[str, ET.Element] = {}
-    links.update(_build_hips(model, spec, p_len, p_rad))
-    links.update(_build_knees(model, spec))
-    links.update(_build_ankles(model, spec))
-    return links
-
-
-def _build_foot_contacts(
-    model: ET.Element,
-    spec: BodyModelSpec,
-    links: dict[str, ET.Element],
-) -> None:
-    """Stage 5: Add foot sole hydroelastic contact geometry to both feet."""
-    _ft_mass, ft_len, _ft_rad = _seg(spec, "foot")
-    for side in ("l", "r"):
-        foot_link = links[f"foot_{side}"]
-        add_contact_geometry(
-            foot_link,
-            name=f"foot_{side}_contact",
-            geometry=make_box_geometry(
-                FOOT_CONTACT_LENGTH,
-                FOOT_CONTACT_WIDTH,
-                FOOT_CONTACT_HEIGHT,
-            ),
-            pose=(0, 0, -ft_len - FOOT_CONTACT_HEIGHT / 2.0, 0, 0, 0),
-        )
-    logger.debug("Added foot sole contact geometry (both sides)")
+__all__ = [
+    "BodyModelSpec",
+    "create_full_body",
+    "_seg",
+    # Re-exported staged builders (kept for backwards compatibility with
+    # existing tests and external callers).
+    "_build_ankles",
+    "_build_elbows",
+    "_build_foot_contacts",
+    "_build_head_link",
+    "_build_hips",
+    "_build_knees",
+    "_build_lower_limbs",
+    "_build_lumbar_joints",
+    "_build_pelvis",
+    "_build_shoulders",
+    "_build_spine_and_head",
+    "_build_upper_limbs",
+    "_build_wrists",
+    "_create_lumbar_virtual_links",
+    "_create_torso_link",
+    "_wire_lumbar_joints",
+]
 
 
 def create_full_body(

--- a/src/drake_models/shared/body/body_trunk.py
+++ b/src/drake_models/shared/body/body_trunk.py
@@ -1,0 +1,212 @@
+"""Trunk builders for the full-body model (pelvis, lumbar spine, head).
+
+Extracted from :mod:`body_model` to keep the orchestration entry point
+under the 300 LOC module budget (issue #127). No behaviour changes.
+"""
+
+from __future__ import annotations
+
+import logging
+import xml.etree.ElementTree as ET
+
+from drake_models.shared.body.body_anthropometrics import (
+    LUMBAR_FLEX_LOWER,
+    LUMBAR_FLEX_UPPER,
+    LUMBAR_LATERAL_LOWER,
+    LUMBAR_LATERAL_UPPER,
+    LUMBAR_ROTATE_LOWER,
+    LUMBAR_ROTATE_UPPER,
+    NECK_RANGE_LIMIT,
+    PELVIS_STANDING_HEIGHT,
+    BodyModelSpec,
+    _seg,
+)
+from drake_models.shared.utils.geometry import (
+    cylinder_inertia,
+    rectangular_prism_inertia,
+)
+from drake_models.shared.utils.sdf_helpers import (
+    add_floating_joint,
+    add_link,
+    add_revolute_joint,
+    add_virtual_link,
+    make_box_geometry,
+    make_cylinder_geometry,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _build_pelvis(
+    model: ET.Element,
+    spec: BodyModelSpec,
+    pelvis_joint_type: str,
+) -> dict[str, ET.Element]:
+    """Stage 1: Create pelvis link and optional world joint.
+
+    Returns dict with the 'pelvis' link element.
+    """
+    links: dict[str, ET.Element] = {}
+    p_mass, p_len, p_rad = _seg(spec, "pelvis")
+    p_inertia = rectangular_prism_inertia(p_mass, p_rad * 2, p_len, p_rad * 2)
+    links["pelvis"] = add_link(
+        model,
+        name="pelvis",
+        mass=p_mass,
+        mass_center=(0, 0, 0),
+        inertia_xx=p_inertia[0],
+        inertia_yy=p_inertia[1],
+        inertia_zz=p_inertia[2],
+        visual_geometry=make_box_geometry(p_rad * 2, p_rad * 2, p_len),
+        collision_geometry=make_box_geometry(p_rad * 2, p_rad * 2, p_len),
+    )
+    if pelvis_joint_type == "fixed":
+        logger.debug(
+            "Skipping world->pelvis joint; exercise builder will weld pelvis externally"
+        )
+    else:
+        add_floating_joint(
+            model,
+            name="ground_pelvis",
+            parent="world",
+            child="pelvis",
+            pose=(0, 0, PELVIS_STANDING_HEIGHT, 0, 0, 0),
+        )
+    return links
+
+
+def _create_lumbar_virtual_links(
+    model: ET.Element,
+) -> dict[str, ET.Element]:
+    """Create the two virtual links used by the lumbar compound joint chain."""
+    return {
+        "lumbar_virtual_1": add_virtual_link(model, name="lumbar_virtual_1"),
+        "lumbar_virtual_2": add_virtual_link(model, name="lumbar_virtual_2"),
+    }
+
+
+def _create_torso_link(
+    model: ET.Element,
+    spec: BodyModelSpec,
+    t_len: float,
+) -> ET.Element:
+    """Create the torso link sized from *spec* with box geometry."""
+    t_mass, _t_len, t_rad = _seg(spec, "torso")
+    t_inertia = rectangular_prism_inertia(t_mass, t_rad * 2, t_len, t_rad * 2)
+    return add_link(
+        model,
+        name="torso",
+        mass=t_mass,
+        mass_center=(0, 0, t_len / 2.0),
+        inertia_xx=t_inertia[0],
+        inertia_yy=t_inertia[1],
+        inertia_zz=t_inertia[2],
+        visual_geometry=make_box_geometry(t_rad * 2, t_rad * 2, t_len),
+        collision_geometry=make_box_geometry(t_rad * 2, t_rad * 2, t_len),
+    )
+
+
+def _wire_lumbar_joints(model: ET.Element, pelvis_length: float) -> None:
+    """Wire the three revolute joints that form the lumbar 3-DOF chain.
+
+    Chain: pelvis -> lumbar_flex (X) -> v1 -> lumbar_lateral (Z)
+           -> v2 -> lumbar_rotate (Y) -> torso.
+    """
+    add_revolute_joint(
+        model,
+        name="lumbar_flex",
+        parent="pelvis",
+        child="lumbar_virtual_1",
+        axis_xyz=(1, 0, 0),
+        pose=(0, 0, pelvis_length / 2.0, 0, 0, 0),
+        lower_limit=LUMBAR_FLEX_LOWER,
+        upper_limit=LUMBAR_FLEX_UPPER,
+    )
+    add_revolute_joint(
+        model,
+        name="lumbar_lateral",
+        parent="lumbar_virtual_1",
+        child="lumbar_virtual_2",
+        axis_xyz=(0, 0, 1),
+        pose=(0, 0, 0, 0, 0, 0),
+        lower_limit=LUMBAR_LATERAL_LOWER,
+        upper_limit=LUMBAR_LATERAL_UPPER,
+    )
+    add_revolute_joint(
+        model,
+        name="lumbar_rotate",
+        parent="lumbar_virtual_2",
+        child="torso",
+        axis_xyz=(0, 1, 0),
+        pose=(0, 0, 0, 0, 0, 0),
+        lower_limit=LUMBAR_ROTATE_LOWER,
+        upper_limit=LUMBAR_ROTATE_UPPER,
+    )
+
+
+def _build_lumbar_joints(
+    model: ET.Element,
+    spec: BodyModelSpec,
+    t_len: float,
+) -> dict[str, ET.Element]:
+    """Create lumbar 3-DOF compound joints and the torso link.
+
+    Chain: pelvis -> lumbar_flex (X) -> v1 -> lumbar_lateral (Z)
+           -> v2 -> lumbar_rotate (Y) -> torso.
+
+    Returns dict containing torso, lumbar_virtual_1, lumbar_virtual_2.
+    """
+    _p_mass, p_len, _p_rad = _seg(spec, "pelvis")
+    links: dict[str, ET.Element] = _create_lumbar_virtual_links(model)
+    links["torso"] = _create_torso_link(model, spec, t_len)
+    _wire_lumbar_joints(model, p_len)
+    return links
+
+
+def _build_head_link(
+    model: ET.Element,
+    spec: BodyModelSpec,
+    t_len: float,
+) -> dict[str, ET.Element]:
+    """Create the head link and neck revolute joint.
+
+    Returns dict containing the head link element.
+    """
+    h_mass, h_len, h_rad = _seg(spec, "head")
+    h_inertia = cylinder_inertia(h_mass, h_rad, h_len)
+    head_link = add_link(
+        model,
+        name="head",
+        mass=h_mass,
+        mass_center=(0, 0, h_len / 2.0),
+        inertia_xx=h_inertia[0],
+        inertia_yy=h_inertia[1],
+        inertia_zz=h_inertia[2],
+        visual_geometry=make_cylinder_geometry(h_rad, h_len),
+        collision_geometry=make_cylinder_geometry(h_rad, h_len),
+    )
+    add_revolute_joint(
+        model,
+        name="neck",
+        parent="torso",
+        child="head",
+        axis_xyz=(1, 0, 0),
+        pose=(0, 0, t_len, 0, 0, 0),
+        lower_limit=-NECK_RANGE_LIMIT,
+        upper_limit=NECK_RANGE_LIMIT,
+    )
+    return {"head": head_link}
+
+
+def _build_spine_and_head(
+    model: ET.Element,
+    spec: BodyModelSpec,
+) -> dict[str, ET.Element]:
+    """Stage 2: Create lumbar 3-DOF compound joint, torso, neck, and head.
+
+    Returns dict with torso, head, and lumbar virtual link elements.
+    """
+    _t_mass, t_len, _t_rad = _seg(spec, "torso")
+    links = _build_lumbar_joints(model, spec, t_len)
+    links.update(_build_head_link(model, spec, t_len))
+    return links


### PR DESCRIPTION
## Summary
- **#126** Decompose oversized Python functions (top 5): every remaining helper is now at most 30 LOC.
- **#127** Split the monolithic `body_model.py` (493 LOC) into three focused modules, each under the 300 LOC module budget.
- Pure refactor — zero behaviour changes, full unit-test suite still passes (376 passed).
- `ruff check` and `ruff format --check` are clean; CLI smoke-tested.

## Functions decomposed (#126)
| File | Function | Before | After | Helpers extracted |
|---|---|---|---|---|
| `src/drake_models/__main__.py` | `_build_arg_parser` | 43 | 10 | `_add_exercise_argument`, `_add_anthropometric_arguments`, `_add_output_arguments` |
| `src/drake_models/exercises/base.py` | `_attach_bilateral_grip` | 44 | 25 | `_validate_grip_preconditions` (DbC check), `_weld_barbell_to_left_hand` |
| `src/drake_models/exercises/base.py` | `_bilateral_collision_pairs` | 39 | 13 | `_lower_body_collision_pairs`, `_upper_body_collision_pairs` |
| `src/drake_models/exercises/base.py` | `build` | 30 | 14 | `_build_body_and_barbell` |
| `scripts/setup_dev.py` | `main` | 38 | 15 | `_require_python_version`, `_init_submodules`, `_install_project`, `_install_vendor_ud_tools` |

`src/drake_models/exercises/bench_press/bench_press_model.py::_add_bench_body` is already 18 LOC (decomposed earlier in #133/#134); no further change needed.

## Scripts split (#127)
| File | Before | After |
|---|---|---|
| `src/drake_models/shared/body/body_model.py` | 493 LOC | 131 LOC (thin orchestrator) |
| `src/drake_models/shared/body/body_trunk.py` | — | 212 LOC (new — pelvis/lumbar/torso/head) |
| `src/drake_models/shared/body/body_limbs.py` | — | 228 LOC (new — upper/lower limbs + foot contact) |

The staged helper functions and `_seg` are re-exported from `body_model` so existing imports (including tests in `tests/unit/shared/test_body_model.py`) continue to resolve.

## Why `trajectory_optimizer.py` is left out
`src/drake_models/optimization/trajectory_optimizer.py` appears in both issue #127 and issue #118 (DbC contracts). It is being refactored in a concurrent branch addressing issue #142 (trajectory dynamics bug) so the two changes stay non-overlapping. Issue #118 should be closed as tracked-in-#142 once that PR lands.

## Test plan
- [x] `python3 -m pytest tests/unit --ignore=tests/unit/optimization --ignore=tests/unit/shared/test_geometry_hypothesis.py -n auto --timeout=60` → 376 passed
- [x] `python3 -m pytest -n auto --timeout=60` → no new failures (remaining failures are pre-existing pydrake-API issues in `tests/integration/test_drake_loading.py` and `tests/unit/optimization/test_inverse_kinematics.py`, plus a `hypothesis` import error — all unrelated to this PR).
- [x] `ruff check src scripts tests` → clean
- [x] `ruff format --check src scripts tests` → clean
- [x] CLI smoke: `python3 -m drake_models squat --mass 80` and `python3 -m drake_models bench_press --mass 75 --height 1.8 --plates 40` both generate valid SDF.

Closes #126
Closes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)