### PR TITLE
Reject non-finite values in contract guards

### DIFF
--- a/src/drake_models/shared/contracts/preconditions.py
+++ b/src/drake_models/shared/contracts/preconditions.py
@@ -11,14 +11,22 @@ import numpy as np
 from numpy.typing import ArrayLike
 
 
+def _require_finite_scalar(value: float, name: str) -> None:
+    """Require *value* to be finite."""
+    if not np.isfinite(value):
+        raise ValueError(f"{name} must be finite, got {value}")
+
+
 def require_positive(value: float, name: str) -> None:
     """Require *value* to be strictly positive."""
+    _require_finite_scalar(value, name)
     if value <= 0:
         raise ValueError(f"{name} must be positive, got {value}")
 
 
 def require_non_negative(value: float, name: str) -> None:
     """Require *value* >= 0."""
+    _require_finite_scalar(value, name)
     if value < 0:
         raise ValueError(f"{name} must be non-negative, got {value}")
 

--- a/tests/unit/shared/test_preconditions.py
+++ b/tests/unit/shared/test_preconditions.py
@@ -17,13 +17,13 @@ class TestRequirePositive:
     def test_accepts_positive(self) -> None:
         require_positive(1.0, "val")
 
-    def test_rejects_zero(self) -> None:
-        with pytest.raises(ValueError, match="must be positive"):
-            require_positive(0.0, "val")
-
-    def test_rejects_negative(self) -> None:
-        with pytest.raises(ValueError, match="must be positive"):
-            require_positive(-1.0, "val")
+    @pytest.mark.parametrize(
+        "value",
+        [0.0, -1.0, float("nan"), float("inf"), float("-inf")],
+    )
+    def test_rejects_invalid_values(self, value: float) -> None:
+        with pytest.raises(ValueError, match="must be (finite|positive)"):
+            require_positive(value, "val")
 
     def test_error_includes_name(self) -> None:
         with pytest.raises(ValueError, match="my_param"):
@@ -41,9 +41,13 @@ class TestRequireNonNegative:
     def test_accepts_positive(self) -> None:
         require_non_negative(5.0, "val")
 
-    def test_rejects_negative(self) -> None:
-        with pytest.raises(ValueError, match="must be non-negative"):
-            require_non_negative(-0.001, "val")
+    @pytest.mark.parametrize(
+        "value",
+        [-0.001, float("nan"), float("inf"), float("-inf")],
+    )
+    def test_rejects_invalid_values(self, value: float) -> None:
+        with pytest.raises(ValueError, match="must be (finite|non-negative)"):
+            require_non_negative(value, "val")
 
 
 class TestRequireUnitVector:


### PR DESCRIPTION
Fixes #143.

`require_positive` and `require_non_negative` now reject NaN and +/-inf before the zero comparison.

Tests:
- PYTHONPATH=src PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 /tmp/drake_models_venv/bin/python -m pytest tests/unit/shared/test_preconditions.py -q