### PR TITLE
[codex] Reject non-finite scalar contract values

### DIFF
--- a/src/drake_models/shared/contracts/preconditions.py
+++ b/src/drake_models/shared/contracts/preconditions.py
@@ -13,12 +13,14 @@ from numpy.typing import ArrayLike
 
 def require_positive(value: float, name: str) -> None:
     """Require *value* to be strictly positive."""
+    require_finite(value, name)
     if value <= 0:
         raise ValueError(f"{name} must be positive, got {value}")
 
 
 def require_non_negative(value: float, name: str) -> None:
     """Require *value* >= 0."""
+    require_finite(value, name)
     if value < 0:
         raise ValueError(f"{name} must be non-negative, got {value}")
 
@@ -42,6 +44,7 @@ def require_finite(arr: ArrayLike, name: str) -> None:
 
 def require_in_range(value: float, low: float, high: float, name: str) -> None:
     """Require *low* <= *value* <= *high*."""
+    require_finite(value, name)
     if not (low <= value <= high):
         raise ValueError(f"{name} must be in [{low}, {high}], got {value}")
 

--- a/tests/unit/shared/test_preconditions.py
+++ b/tests/unit/shared/test_preconditions.py
@@ -17,6 +17,11 @@ class TestRequirePositive:
     def test_accepts_positive(self) -> None:
         require_positive(1.0, "val")
 
+    @pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")])
+    def test_rejects_non_finite(self, value: float) -> None:
+        with pytest.raises(ValueError, match="non-finite"):
+            require_positive(value, "val")
+
     def test_rejects_zero(self) -> None:
         with pytest.raises(ValueError, match="must be positive"):
             require_positive(0.0, "val")
@@ -44,6 +49,11 @@ class TestRequireNonNegative:
     def test_rejects_negative(self) -> None:
         with pytest.raises(ValueError, match="must be non-negative"):
             require_non_negative(-0.001, "val")
+
+    @pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")])
+    def test_rejects_non_finite(self, value: float) -> None:
+        with pytest.raises(ValueError, match="non-finite"):
+            require_non_negative(value, "val")
 
 
 class TestRequireUnitVector:
@@ -106,6 +116,11 @@ class TestRequireInRange:
     def test_rejects_above(self) -> None:
         with pytest.raises(ValueError, match="must be in"):
             require_in_range(11, 0, 10, "val")
+
+    @pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")])
+    def test_rejects_non_finite(self, value: float) -> None:
+        with pytest.raises(ValueError, match="non-finite"):
+            require_in_range(value, 0, 10, "val")
 
 
 class TestRequireShape:


### PR DESCRIPTION
## Summary
- Reject NaN and infinity in scalar precondition guards before positive, non-negative, and range comparisons.
- Adds regression coverage for the reported issue.

Closes #143

## Validation
- TMPDIR=/tmp PYTHONPATH=src python3 -m pytest tests/unit/shared/test_preconditions.py -q; python3 -m ruff check src/drake_models/shared/contracts/preconditions.py tests/unit/shared/test_preconditions.py; python3 -m black --check src/drake_models/shared/contracts/preconditions.py tests/unit/shared/test_preconditions.py
