### PR TITLE
[codex] split exercise factory config assembly

### DIFF
--- a/src/drake_models/exercises/factory.py
+++ b/src/drake_models/exercises/factory.py
@@ -18,6 +18,30 @@ from drake_models.shared.barbell import BarbellSpec
 from drake_models.shared.body import BodyModelSpec
 
 
+def _build_exercise_config(
+    body_mass: float,
+    height: float,
+    plate_mass_per_side: float,
+    *,
+    include_barbell: bool,
+) -> ExerciseConfig:
+    """Construct the shared exercise configuration for the factory.
+
+    Preconditions:
+        ``body_mass > 0``, ``height > 0``, ``plate_mass_per_side >= 0``
+        (enforced by the dataclass validators on the returned specs).
+    """
+    body_spec = BodyModelSpec(total_mass=body_mass, height=height)
+    if include_barbell:
+        return ExerciseConfig(
+            body_spec=body_spec,
+            barbell_spec=BarbellSpec.mens_olympic(
+                plate_mass_per_side=plate_mass_per_side,
+            ),
+        )
+    return ExerciseConfig(body_spec=body_spec)
+
+
 def build_exercise_model(
     builder_cls: type[ExerciseModelBuilder],
     body_mass: float = 80.0,
@@ -26,41 +50,11 @@ def build_exercise_model(
     *,
     include_barbell: bool = True,
 ) -> str:
-    """Build an exercise SDF model from a builder class and scalar parameters.
-
-    This is the generic implementation behind the per-exercise
-    ``build_*_model`` helpers. It constructs an :class:`ExerciseConfig`,
-    instantiates ``builder_cls`` with that config, and returns the SDF
-    XML string produced by ``.build()``.
-
-    Args:
-        builder_cls: Concrete :class:`ExerciseModelBuilder` subclass to
-            instantiate (e.g. ``SquatModelBuilder``).
-        body_mass: Total body mass in kilograms.
-        height: Body height in meters.
-        plate_mass_per_side: Mass of plates loaded on each side of the
-            barbell in kilograms. Ignored when ``include_barbell`` is
-            ``False`` (e.g. gait, sit-to-stand).
-        include_barbell: If ``True`` (default), pass a configured
-            :class:`BarbellSpec` to the config. If ``False``, use the
-            config default — useful for bodyweight-only exercises that
-            still accept ``plate_mass_per_side`` for CLI compatibility.
-
-    Returns:
-        SDF 1.8 XML string describing the full exercise model.
-
-    Preconditions:
-        ``body_mass > 0``, ``height > 0``, ``plate_mass_per_side >= 0``
-        (enforced downstream by :class:`BodyModelSpec` / :class:`BarbellSpec`).
-    """
-    body_spec = BodyModelSpec(total_mass=body_mass, height=height)
-    if include_barbell:
-        config = ExerciseConfig(
-            body_spec=body_spec,
-            barbell_spec=BarbellSpec.mens_olympic(
-                plate_mass_per_side=plate_mass_per_side,
-            ),
-        )
-    else:
-        config = ExerciseConfig(body_spec=body_spec)
+    """Build a model from a builder class and scalar parameters."""
+    config = _build_exercise_config(
+        body_mass,
+        height,
+        plate_mass_per_side,
+        include_barbell=include_barbell,
+    )
     return builder_cls(config).build()

--- a/tests/unit/exercises/test_factory.py
+++ b/tests/unit/exercises/test_factory.py
@@ -22,7 +22,10 @@ from drake_models.exercises.deadlift.deadlift_model import (
     DeadliftModelBuilder,
     build_deadlift_model,
 )
-from drake_models.exercises.factory import build_exercise_model
+from drake_models.exercises.factory import (
+    _build_exercise_config,
+    build_exercise_model,
+)
 from drake_models.exercises.gait.gait_model import (
     GaitModelBuilder,
     build_gait_model,
@@ -37,6 +40,30 @@ from drake_models.exercises.squat.squat_model import (
 )
 from drake_models.shared.barbell import BarbellSpec
 from drake_models.shared.body import BodyModelSpec
+
+
+class TestBuildExerciseConfig:
+    """Focused tests for the extracted config-construction helper."""
+
+    def test_builds_barbell_config_when_enabled(self) -> None:
+        config = _build_exercise_config(
+            body_mass=82.5,
+            height=1.81,
+            plate_mass_per_side=42.0,
+            include_barbell=True,
+        )
+        assert config.body_spec == BodyModelSpec(total_mass=82.5, height=1.81)
+        assert config.barbell_spec == BarbellSpec.mens_olympic(plate_mass_per_side=42.0)
+
+    def test_uses_default_barbell_config_when_disabled(self) -> None:
+        config = _build_exercise_config(
+            body_mass=79.0,
+            height=1.74,
+            plate_mass_per_side=99.0,
+            include_barbell=False,
+        )
+        assert config.body_spec == BodyModelSpec(total_mass=79.0, height=1.74)
+        assert config.barbell_spec == ExerciseConfig().barbell_spec
 
 
 class TestBuildExerciseModelFactory:


### PR DESCRIPTION
Addresses a bounded slice of #129 by pulling the shared exercise config construction out of `build_exercise_model()` into `_build_exercise_config()`.

This keeps the public factory path thin, preserves the existing XML parity guarantees, and adds focused tests for the new helper’s barbell and bodyweight branches.

Checks:
- `PYTHONPATH=src /tmp/drake_models_ci/bin/python -m pytest tests/unit/exercises/test_factory.py -q`
- `/tmp/drake_models_ci/bin/python -m ruff check src/drake_models/exercises/factory.py tests/unit/exercises/test_factory.py`
- `/tmp/drake_models_ci/bin/python -m black --check src/drake_models/exercises/factory.py tests/unit/exercises/test_factory.py`
- `/tmp/drake_models_ci/bin/python -m mypy src/drake_models/exercises/factory.py tests/unit/exercises/test_factory.py`