### PR TITLE
refactor: split bench pad placement helpers

### DIFF
--- a/src/drake_models/exercises/bench_press/bench_press_model.py
+++ b/src/drake_models/exercises/bench_press/bench_press_model.py
@@ -82,6 +82,22 @@ class BenchPressModelBuilder(ExerciseModelBuilder):
         return "fixed"
 
     @staticmethod
+    def _bench_pad_z_center() -> float:
+        """Return bench-pad center height that places the top at BENCH_HEIGHT."""
+        return BENCH_HEIGHT - BENCH_PAD_THICKNESS / 2.0
+
+    @staticmethod
+    def _add_bench_to_world_joint(model: ET.Element) -> None:
+        """Weld the bench pad to world at its computed center height."""
+        add_fixed_joint(
+            model,
+            name="bench_to_world",
+            parent="world",
+            child="bench_pad",
+            pose=(0, 0, BenchPressModelBuilder._bench_pad_z_center(), 0, 0, 0),
+        )
+
+    @staticmethod
     def _create_bench_pad_link(model: ET.Element) -> ET.Element:
         """Create the bench pad link with inertia and visual/collision geometry."""
         inertia = rectangular_prism_inertia(
@@ -124,17 +140,13 @@ class BenchPressModelBuilder(ExerciseModelBuilder):
         The bench pad is a box welded to the world frame at BENCH_HEIGHT so
         that its top surface sits at exactly BENCH_HEIGHT meters above ground.
         """
-        pad_z_center = BENCH_HEIGHT - BENCH_PAD_THICKNESS / 2.0
         bench_link = self._create_bench_pad_link(model)
-        add_fixed_joint(
-            model,
-            name="bench_to_world",
-            parent="world",
-            child="bench_pad",
-            pose=(0, 0, pad_z_center, 0, 0, 0),
-        )
+        self._add_bench_to_world_joint(model)
         self._add_bench_pad_contact(bench_link)
-        logger.debug("Added bench pad welded to world at z=%.3f m", pad_z_center)
+        logger.debug(
+            "Added bench pad welded to world at z=%.3f m",
+            self._bench_pad_z_center(),
+        )
         return bench_link
 
     def _weld_pelvis_to_bench(self, model: ET.Element) -> None:

--- a/tests/unit/exercises/test_bench_press.py
+++ b/tests/unit/exercises/test_bench_press.py
@@ -6,6 +6,7 @@ import pytest
 
 from drake_models.exercises.bench_press.bench_press_model import (
     BENCH_HEIGHT,
+    BENCH_PAD_THICKNESS,
     BenchPressModelBuilder,
     build_bench_press_model,
 )
@@ -52,6 +53,21 @@ class TestBenchPressModelBuilder:
 
     def test_bench_height_constant(self) -> None:
         assert pytest.approx(0.43) == BENCH_HEIGHT
+
+    def test_bench_pad_z_center_places_top_at_bench_height(self) -> None:
+        z_center = BenchPressModelBuilder._bench_pad_z_center()
+        assert z_center + (BENCH_PAD_THICKNESS / 2.0) == pytest.approx(BENCH_HEIGHT)
+
+    def test_add_bench_to_world_joint_uses_computed_height(self) -> None:
+        model = ET.Element("model")
+        BenchPressModelBuilder._add_bench_to_world_joint(model)
+        joint = model.find("joint[@name='bench_to_world']")
+        assert joint is not None
+        pose = joint.find("pose")
+        assert pose is not None
+        assert float(pose.text.split()[2]) == pytest.approx(
+            BenchPressModelBuilder._bench_pad_z_center()
+        )
 
     def test_has_gravity(self) -> None:
         xml_str = build_bench_press_model()


### PR DESCRIPTION
## Summary
- split bench-pad center-height calculation and world weld creation into focused helpers
- add tests that pin the placement calculation and generated bench_to_world joint pose

## Validation
- `TMPDIR=/tmp PYTHONPATH=src python3 -m pytest tests/unit/exercises/test_bench_press.py -q`
- `python3 -m ruff check src/drake_models/exercises/bench_press/bench_press_model.py tests/unit/exercises/test_bench_press.py`
- `python3 -m black --check src/drake_models/exercises/bench_press/bench_press_model.py tests/unit/exercises/test_bench_press.py`

Refs #129
