### PR TITLE
refactor: split setup dev orchestration

### DIFF
--- a/scripts/setup_dev.py
+++ b/scripts/setup_dev.py
@@ -52,6 +52,21 @@ def _install_vendor_ud_tools() -> None:
     )
 
 
+def _bootstrap_steps() -> tuple:
+    """Return the ordered setup steps for the developer bootstrap flow."""
+    return (
+        _require_python_version,
+        _init_submodules,
+        _install_project,
+        _install_vendor_ud_tools,
+    )
+
+
+def _report_ready() -> None:
+    """Print the final success message for humans running the script."""
+    print("[ OK ] Development environment ready!")
+
+
 def main() -> None:
     """Bootstrap the developer environment for Drake_Models.
 
@@ -62,11 +77,9 @@ def main() -> None:
         SystemExit: If the Python version is below the minimum or if
             vendor/ud-tools is not found.
     """
-    _require_python_version()
-    _init_submodules()
-    _install_project()
-    _install_vendor_ud_tools()
-    print("[ OK ] Development environment ready!")
+    for step in _bootstrap_steps():
+        step()
+    _report_ready()
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_setup_dev.py
+++ b/tests/unit/test_setup_dev.py
@@ -1,0 +1,37 @@
+"""Tests for the developer setup script orchestration helpers."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+def _load_module() -> object:
+    repo_root = Path(__file__).resolve().parents[2]
+    script = repo_root / "scripts" / "setup_dev.py"
+    spec = importlib.util.spec_from_file_location("setup_dev", script)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_bootstrap_steps_preserves_setup_order() -> None:
+    mod = _load_module()
+
+    steps = mod._bootstrap_steps()  # type: ignore[attr-defined]
+
+    assert [step.__name__ for step in steps] == [
+        "_require_python_version",
+        "_init_submodules",
+        "_install_project",
+        "_install_vendor_ud_tools",
+    ]
+
+
+def test_report_ready_prints_success_message(capsys) -> None:
+    mod = _load_module()
+
+    mod._report_ready()  # type: ignore[attr-defined]
+
+    assert "Development environment ready" in capsys.readouterr().out


### PR DESCRIPTION
## Summary
- split setup_dev orchestration into ordered bootstrap steps and a success reporter
- add tests for step order and ready-message reporting without running install commands

## Validation
- `TMPDIR=/tmp PYTHONPATH=src python3 -m pytest tests/unit/test_setup_dev.py -q`
- `python3 -m ruff check scripts/setup_dev.py tests/unit/test_setup_dev.py`
- `python3 -m black --check scripts/setup_dev.py tests/unit/test_setup_dev.py`

Refs #129
