### PR TITLE
⚡ Bolt: [performance improvement] Hoist invariant np.eye allocations in _add_phase_tracking_costs

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -23,3 +23,6 @@
 ## 2025-05-18 - Loop-Invariant Hoisting in Trajectory Setup
 **Learning:** In Drake trajectory setup routines (like `_add_control_costs`), generating matrices like `weight * np.eye(n_u)` or `np.zeros(n_u)` inside the loop over `n_steps` incurs massive overhead. In our test, placing allocations inside the loop was ~70x slower than pre-computing them.
 **Action:** Always hoist loop-invariant matrix/array allocations (like `np.zeros`, `np.eye`, `np.ones`) outside the `n_steps` loops when setting up costs and constraints for mathematical programs.
+## 2025-05-18 - Loop-Invariant Allocation Hoisting in Phase Setup
+**Learning:** Even in loops with a smaller number of iterations (like phase setups), repeatedly generating constant dense matrices with `np.eye()` incurs unnecessary allocation overhead and time complexity. In Drake programs, these matrices can be safely precomputed and reused across multiple `AddQuadraticCost` calls.
+**Action:** Always identify identical, loop-invariant matrices (like state and terminal Q matrices) and extract their computation to before the loop.

--- a/src/drake_models/optimization/drake_trajectory_solver.py
+++ b/src/drake_models/optimization/drake_trajectory_solver.py
@@ -167,6 +167,11 @@ def _add_phase_tracking_costs(
 ) -> None:
     """Add phase-tracking quadratic costs to *prog*."""
     joint_names = objective.joint_names()
+
+    # Optimize: pre-calculate constant Q matrices to avoid allocation overhead in loop
+    Q_state = state_weight * np.eye(n_q)
+    Q_terminal = terminal_weight * np.eye(n_q)
+
     for phase in objective.phases:
         k = int(phase.time_fraction * (n_steps - 1))
         target = np.zeros(n_q)
@@ -175,9 +180,12 @@ def _add_phase_tracking_costs(
                 idx = joint_names.index(jname)
                 if idx < n_q:
                     target[idx] = angle
+
         weight = terminal_weight if phase is objective.phases[-1] else state_weight
+        Q = Q_terminal if phase is objective.phases[-1] else Q_state
+
         prog.AddQuadraticCost(  # type: ignore[attr-defined]
-            weight * np.eye(n_q),
+            Q,
             -weight * target,
             q[k],  # type: ignore[index]
         )


### PR DESCRIPTION
💡 What: Hoisted the state and terminal `np.eye` matrix allocations out of the `objective.phases` loop in `_add_phase_tracking_costs`.

🎯 Why: To prevent the repeated instantiation of dense diagonal matrices, which introduces memory allocation and processing overhead, particularly when adding numerous sequential constraints in mathematical programs. Re-using the initialized Q matrix reduces loop costs.

📊 Impact: Decreases intermediate array allocations and slightly reduces setup time for `drake_trajectory_solver.py` without impacting solver correctness, as Drake reads the matrix values instead of altering the references.

🔬 Measurement: Verified functionality and constraint application precision using `pytest tests/unit/optimization/test_drake_trajectory_solver_helpers.py` and overall codebase tests. All 735 tests pass smoothly.

---
*PR created automatically by Jules for task [15401676420116651812](https://jules.google.com/task/15401676420116651812) started by @dieterolson*