### PR TITLE
fix(ci): consolidate tool versions into pyproject.toml (fixes #190)

### DIFF
--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -53,7 +53,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v6
         with: { python-version: "3.11" }
-      - run: pip install "ruff==0.14.10" "mypy==1.13.0" "bandit==1.7.7"
+      - run: pip install -e ".[dev]"
 
       - name: Lint
         run: ruff check src scripts tests examples
@@ -61,8 +61,6 @@ jobs:
       - name: Check Formatting (ruff)
         run: ruff format --check src scripts tests examples
 
-      - run: pip install mypy types-PyYAML types-requests
-      - run: pip install -e .[dev]
       - run: mypy src --config-file pyproject.toml
 
       - name: Verify No Placeholders

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,10 @@ dev = [
     "pytest-xdist>=3.8.0",
     "ruff>=0.14.0",
     "mypy>=1.15.0",
+    "types-PyYAML",
+    "types-requests",
     "hypothesis>=6.151.12",
+    "bandit>=1.7.7",
 ]
 
 [project.urls]


### PR DESCRIPTION
## Summary
Removes hardcoded version pins from CI workflow and delegates to `pyproject.toml` as the single source of truth for all development tool versions.

## Changes
- **pyproject.toml**: Added `bandit>=1.7.7`, `types-PyYAML`, and `types-requests` to `[project.optional-dependencies.dev]`
- **.github/workflows/ci-standard.yml**: Removed inline `pip install "ruff==..." "mypy==..." "bandit==..."` and the redundant `pip install mypy types-PyYAML types-requests` step. All tools are now installed via `pip install -e ".[dev]"`

## Acceptance Criteria Verification
- [x] Single source of truth for tool versions: `pyproject.toml`
- [x] CI `mypy` version matches `pyproject.toml` minimum (`>=1.15.0`)
- [x] `bandit` added to dev dependencies in `pyproject.toml`
- [x] No tool version specified in both the workflow and `pyproject.toml`

Fixes #190