### PR TITLE
ci: fix actions/checkout and setup-python to valid versions (#190)

### DIFF
--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -48,10 +48,10 @@ jobs:
     runs-on: ${{ needs.pick-runner.outputs.runner }}
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v5
         with: { python-version: "3.11" }
       - run: pip install -e ".[dev]"
 
@@ -92,8 +92,8 @@ jobs:
       matrix:
         python: ["3.10", "3.11", "3.12"]
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
 


### PR DESCRIPTION
Fixes #190

Replaces non-existent action versions with valid, current releases:

- `actions/checkout@v6` → `actions/checkout@v4`
- `actions/setup-python@v6` → `actions/setup-python@v5`

Using v6 caused workflow failures because GitHub has never published those major versions. The pinned v4/v5 versions are stable and align with the rest of the D-sorganization fleet (see MuJoCo_Models commit d37c263 for identical fix).

This resolves the CI tool version split reported in #190 where workflows were failing due to invalid action references.