### PR TITLE
Fix #185: Remove 237 type: ignore suppressions

### DIFF
--- a/src/drake_models/shared/body/body_segments.py
+++ b/src/drake_models/shared/body/body_segments.py
@@ -273,8 +273,12 @@ def _add_compound_3dof_bilateral(
             rotate_label=rotate_label,
         )
         # Record the virtual links so callers can inspect / query them
-        created[v1] = model.find(f"link[@name='{v1}']")  # type: ignore[assignment]
-        created[v2] = model.find(f"link[@name='{v2}']")  # type: ignore[assignment]
+        el1 = model.find(f"link[@name='{v1}']")
+        assert el1 is not None
+        created[v1] = el1
+        el2 = model.find(f"link[@name='{v2}']")
+        assert el2 is not None
+        created[v2] = el2
 
     return created
 
@@ -363,6 +367,8 @@ def _add_compound_2dof_bilateral(
             second_limits=second_limits,
             second_label=second_label,
         )
-        created[v1] = model.find(f"link[@name='{v1}']")  # type: ignore[assignment]
+        el1 = model.find(f"link[@name='{v1}']")
+        assert el1 is not None
+        created[v1] = el1
 
     return created

--- a/tests/unit/exercises/test_bench_press.py
+++ b/tests/unit/exercises/test_bench_press.py
@@ -25,31 +25,33 @@ class TestBenchPressModelBuilder:
     def test_model_name(self) -> None:
         xml_str = build_bench_press_model()
         root = ET.fromstring(xml_str)
-        model = root.find("model")  # type: ignore
+        model = root.find("model")
         assert model is not None
-        assert model.get("name") == "bench_press"  # type: ignore
+        assert model.get("name") == "bench_press"
 
     def test_barbell_attached_to_left_hand(self) -> None:
         xml_str = build_bench_press_model()
         root = ET.fromstring(xml_str)
         for j in root.findall(".//joint"):
-            if j.get("name") == "barbell_to_left_hand":  # type: ignore
-                assert j.find("parent").text == "hand_l"  # type: ignore
-                assert j.find("child").text == "barbell_shaft"  # type: ignore
+            if j.get("name") == "barbell_to_left_hand":
+                parent = j.find("parent")
+                child = j.find("child")
+                assert parent is not None and parent.text == "hand_l"
+                assert child is not None and child.text == "barbell_shaft"
 
     def test_barbell_grip_joint_present(self) -> None:
         """barbell_to_left_hand joint must be present (single SDF-tree-safe grip)."""
         xml_str = build_bench_press_model()
         root = ET.fromstring(xml_str)
-        joint_names = {j.get("name") for j in root.findall(".//joint")}  # type: ignore
-        assert "barbell_to_left_hand" in joint_names  # type: ignore
+        joint_names = {j.get("name") for j in root.findall(".//joint")}
+        assert "barbell_to_left_hand" in joint_names
 
     def test_attachment_is_fixed(self) -> None:
         xml_str = build_bench_press_model()
         root = ET.fromstring(xml_str)
         for j in root.findall(".//joint"):
-            if j.get("name") == "barbell_to_left_hand":  # type: ignore
-                assert j.get("type") == "fixed"  # type: ignore
+            if j.get("name") == "barbell_to_left_hand":
+                assert j.get("type") == "fixed"
 
     def test_bench_height_constant(self) -> None:
         assert pytest.approx(0.43) == BENCH_HEIGHT
@@ -65,6 +67,7 @@ class TestBenchPressModelBuilder:
         assert joint is not None
         pose = joint.find("pose")
         assert pose is not None
+        assert pose.text is not None
         assert float(pose.text.split()[2]) == pytest.approx(
             BenchPressModelBuilder._bench_pad_z_center()
         )
@@ -72,24 +75,25 @@ class TestBenchPressModelBuilder:
     def test_has_gravity(self) -> None:
         xml_str = build_bench_press_model()
         root = ET.fromstring(xml_str)
-        gravity = root.find(".//gravity")  # type: ignore
+        gravity = root.find(".//gravity")
         assert gravity is not None
-        assert "-9.806650" in gravity.text  # type: ignore
+        assert gravity.text is not None
+        assert "-9.806650" in gravity.text
 
     def test_has_initial_pose(self) -> None:
         xml_str = build_bench_press_model()
         root = ET.fromstring(xml_str)
-        initial_pose = root.find(".//initial_pose")  # type: ignore
+        initial_pose = root.find(".//initial_pose")
         assert initial_pose is not None
-        assert initial_pose.get("name") == "lockout"  # type: ignore
-        joints = initial_pose.findall("joint")  # type: ignore
+        assert initial_pose.get("name") == "lockout"
+        joints = initial_pose.findall("joint")
         assert len(joints) > 0, "initial_pose must contain at least one joint element"
 
     def test_default_config(self) -> None:
         builder = BenchPressModelBuilder()
-        assert builder.config.body_spec.total_mass == 80.0  # type: ignore
+        assert builder.config.body_spec.total_mass == 80.0
 
     def test_custom_plate_mass(self) -> None:
         xml_str = build_bench_press_model(plate_mass_per_side=70.0)
         root = ET.fromstring(xml_str)
-        assert root.find(".//model") is not None  # type: ignore
+        assert root.find(".//model") is not None

--- a/tests/unit/exercises/test_clean_and_jerk.py
+++ b/tests/unit/exercises/test_clean_and_jerk.py
@@ -21,51 +21,54 @@ class TestCleanAndJerkModelBuilder:
     def test_model_name(self) -> None:
         xml_str = build_clean_and_jerk_model()
         root = ET.fromstring(xml_str)
-        model = root.find("model")  # type: ignore
+        model = root.find("model")
         assert model is not None
-        assert model.get("name") == "clean_and_jerk"  # type: ignore
+        assert model.get("name") == "clean_and_jerk"
 
     def test_barbell_attached_to_left_hand(self) -> None:
         xml_str = build_clean_and_jerk_model()
         root = ET.fromstring(xml_str)
         for j in root.findall(".//joint"):
-            if j.get("name") == "barbell_to_left_hand":  # type: ignore
-                assert j.find("parent").text == "hand_l"  # type: ignore
-                assert j.find("child").text == "barbell_shaft"  # type: ignore
+            if j.get("name") == "barbell_to_left_hand":
+                parent = j.find("parent")
+                child = j.find("child")
+                assert parent is not None and parent.text == "hand_l"
+                assert child is not None and child.text == "barbell_shaft"
 
     def test_barbell_grip_joint_present(self) -> None:
         """barbell_to_left_hand joint must be present (single SDF-tree-safe grip)."""
         xml_str = build_clean_and_jerk_model()
         root = ET.fromstring(xml_str)
-        joint_names = {j.get("name") for j in root.findall(".//joint")}  # type: ignore
-        assert "barbell_to_left_hand" in joint_names  # type: ignore
+        joint_names = {j.get("name") for j in root.findall(".//joint")}
+        assert "barbell_to_left_hand" in joint_names
 
     def test_attachment_is_fixed(self) -> None:
         xml_str = build_clean_and_jerk_model()
         root = ET.fromstring(xml_str)
         for j in root.findall(".//joint"):
-            if j.get("name") == "barbell_to_left_hand":  # type: ignore
-                assert j.get("type") == "fixed"  # type: ignore
+            if j.get("name") == "barbell_to_left_hand":
+                assert j.get("type") == "fixed"
 
     def test_has_gravity(self) -> None:
         xml_str = build_clean_and_jerk_model()
         root = ET.fromstring(xml_str)
-        gravity = root.find(".//gravity")  # type: ignore
+        gravity = root.find(".//gravity")
         assert gravity is not None
-        assert "-9.806650" in gravity.text  # type: ignore
+        assert gravity.text is not None
+        assert "-9.806650" in gravity.text
 
     def test_has_initial_pose(self) -> None:
         xml_str = build_clean_and_jerk_model()
         root = ET.fromstring(xml_str)
-        initial_pose = root.find(".//initial_pose")  # type: ignore
+        initial_pose = root.find(".//initial_pose")
         assert initial_pose is not None
-        assert initial_pose.get("name") == "clean_setup"  # type: ignore
-        joints = initial_pose.findall("joint")  # type: ignore
+        assert initial_pose.get("name") == "clean_setup"
+        joints = initial_pose.findall("joint")
         assert len(joints) > 0, "initial_pose must contain at least one joint element"
 
     def test_default_config(self) -> None:
         builder = CleanAndJerkModelBuilder()
-        assert builder.config.body_spec.total_mass == 80.0  # type: ignore
+        assert builder.config.body_spec.total_mass == 80.0
 
     def test_custom_params(self) -> None:
         xml_str = build_clean_and_jerk_model(
@@ -74,6 +77,6 @@ class TestCleanAndJerkModelBuilder:
             plate_mass_per_side=60,
         )
         root = ET.fromstring(xml_str)
-        model = root.find(".//model")  # type: ignore
+        model = root.find(".//model")
         assert model is not None
-        assert model.get("name") == "clean_and_jerk"  # type: ignore
+        assert model.get("name") == "clean_and_jerk"

--- a/tests/unit/exercises/test_deadlift.py
+++ b/tests/unit/exercises/test_deadlift.py
@@ -24,31 +24,33 @@ class TestDeadliftModelBuilder:
     def test_model_name(self) -> None:
         xml_str = build_deadlift_model()
         root = ET.fromstring(xml_str)
-        model = root.find("model")  # type: ignore
+        model = root.find("model")
         assert model is not None
-        assert model.get("name") == "deadlift"  # type: ignore
+        assert model.get("name") == "deadlift"
 
     def test_barbell_attached_to_left_hand(self) -> None:
         xml_str = build_deadlift_model()
         root = ET.fromstring(xml_str)
         for j in root.findall(".//joint"):
-            if j.get("name") == "barbell_to_left_hand":  # type: ignore
-                assert j.find("parent").text == "hand_l"  # type: ignore
-                assert j.find("child").text == "barbell_shaft"  # type: ignore
+            if j.get("name") == "barbell_to_left_hand":
+                parent = j.find("parent")
+                child = j.find("child")
+                assert parent is not None and parent.text == "hand_l"
+                assert child is not None and child.text == "barbell_shaft"
 
     def test_barbell_grip_joint_present(self) -> None:
         """barbell_to_left_hand joint must be present (single SDF-tree-safe grip)."""
         xml_str = build_deadlift_model()
         root = ET.fromstring(xml_str)
-        joint_names = {j.get("name") for j in root.findall(".//joint")}  # type: ignore
-        assert "barbell_to_left_hand" in joint_names  # type: ignore
+        joint_names = {j.get("name") for j in root.findall(".//joint")}
+        assert "barbell_to_left_hand" in joint_names
 
     def test_attachment_is_fixed(self) -> None:
         xml_str = build_deadlift_model()
         root = ET.fromstring(xml_str)
         for j in root.findall(".//joint"):
-            if j.get("name") == "barbell_to_left_hand":  # type: ignore
-                assert j.get("type") == "fixed"  # type: ignore
+            if j.get("name") == "barbell_to_left_hand":
+                assert j.get("type") == "fixed"
 
     def test_grip_offset_constant(self) -> None:
         assert pytest.approx(0.22) == GRIP_OFFSET
@@ -56,27 +58,28 @@ class TestDeadliftModelBuilder:
     def test_has_gravity(self) -> None:
         xml_str = build_deadlift_model()
         root = ET.fromstring(xml_str)
-        gravity = root.find(".//gravity")  # type: ignore
+        gravity = root.find(".//gravity")
         assert gravity is not None
-        assert "-9.806650" in gravity.text  # type: ignore
+        assert gravity.text is not None
+        assert "-9.806650" in gravity.text
 
     def test_has_initial_pose(self) -> None:
         xml_str = build_deadlift_model()
         root = ET.fromstring(xml_str)
-        initial_pose = root.find(".//initial_pose")  # type: ignore
+        initial_pose = root.find(".//initial_pose")
         assert initial_pose is not None
-        assert initial_pose.get("name") == "setup"  # type: ignore
-        joints = initial_pose.findall("joint")  # type: ignore
+        assert initial_pose.get("name") == "setup"
+        joints = initial_pose.findall("joint")
         assert len(joints) > 0, "initial_pose must contain at least one joint element"
 
     def test_default_plate_mass(self) -> None:
         xml_str = build_deadlift_model()
         root = ET.fromstring(xml_str)
-        assert root.find(".//model") is not None  # type: ignore
+        assert root.find(".//model") is not None
 
     def test_custom_body_params(self) -> None:
         xml_str = build_deadlift_model(body_mass=100, height=1.90)
         root = ET.fromstring(xml_str)
-        model = root.find(".//model")  # type: ignore
+        model = root.find(".//model")
         assert model is not None
-        assert model.get("name") == "deadlift"  # type: ignore
+        assert model.get("name") == "deadlift"

--- a/tests/unit/exercises/test_gait.py
+++ b/tests/unit/exercises/test_gait.py
@@ -18,26 +18,26 @@ class TestGaitModelBuilder:
     def test_build_returns_xml_string(self) -> None:
         xml_str = build_gait_model()
         assert isinstance(xml_str, str)
-        assert "<?xml" in xml_str  # type: ignore
+        assert "<?xml" in xml_str
 
     def test_valid_sdf(self) -> None:
         xml_str = build_gait_model()
         root = ET.fromstring(xml_str)
         assert root.tag == "sdf"
-        assert root.get("version") == "1.8"  # type: ignore
+        assert root.get("version") == "1.8"
 
     def test_model_name(self) -> None:
         xml_str = build_gait_model()
         root = ET.fromstring(xml_str)
-        model = root.find("model")  # type: ignore
+        model = root.find("model")
         assert model is not None
-        assert model.get("name") == "gait"  # type: ignore
+        assert model.get("name") == "gait"
 
     def test_no_barbell_attachment_joint(self) -> None:
         """Gait model should not have a barbell-to-body joint."""
         xml_str = build_gait_model()
         root = ET.fromstring(xml_str)
-        joints = {j.get("name") for j in root.findall(".//joint")}  # type: ignore
+        joints = {j.get("name") for j in root.findall(".//joint")}
         barbell_joints = [n for n in joints if n and "barbell" in n.lower()]
         # Barbell links exist but no joint connecting barbell to body
         assert not any("barbell_to" in (n or "") for n in joints), (
@@ -47,29 +47,31 @@ class TestGaitModelBuilder:
     def test_has_initial_pose(self) -> None:
         xml_str = build_gait_model()
         root = ET.fromstring(xml_str)
-        initial_pose = root.find(".//initial_pose")  # type: ignore
+        initial_pose = root.find(".//initial_pose")
         assert initial_pose is not None
-        assert initial_pose.get("name") == "mid_stride"  # type: ignore
-        joints = initial_pose.findall("joint")  # type: ignore
+        assert initial_pose.get("name") == "mid_stride"
+        joints = initial_pose.findall("joint")
         assert len(joints) > 0, "initial_pose must contain at least one joint element"
 
     def test_initial_pose_has_asymmetric_hips(self) -> None:
         """Mid-stride should have different left/right hip angles."""
         xml_str = build_gait_model()
         root = ET.fromstring(xml_str)
-        initial_pose = root.find(".//initial_pose")  # type: ignore
+        initial_pose = root.find(".//initial_pose")
         assert initial_pose is not None
         joint_values = {}
-        for j in initial_pose.findall("joint"):  # type: ignore
-            joint_values[j.get("name")] = float(j.text)  # type: ignore
+        for j in initial_pose.findall("joint"):
+            assert j.text is not None
+            joint_values[j.get("name")] = float(j.text)
         assert joint_values["hip_l_flex"] != joint_values["hip_r_flex"]
 
     def test_has_gravity(self) -> None:
         xml_str = build_gait_model()
         root = ET.fromstring(xml_str)
-        gravity = root.find(".//gravity")  # type: ignore
+        gravity = root.find(".//gravity")
         assert gravity is not None
-        assert "-9.806650" in gravity.text  # type: ignore
+        assert gravity.text is not None
+        assert "-9.806650" in gravity.text
 
     def test_custom_config(self) -> None:
         config = ExerciseConfig(
@@ -78,6 +80,6 @@ class TestGaitModelBuilder:
         builder = GaitModelBuilder(config)
         xml_str = builder.build()
         root = ET.fromstring(xml_str)
-        model = root.find(".//model")  # type: ignore
+        model = root.find(".//model")
         assert model is not None
-        assert model.get("name") == "gait"  # type: ignore
+        assert model.get("name") == "gait"

--- a/tests/unit/exercises/test_sit_to_stand.py
+++ b/tests/unit/exercises/test_sit_to_stand.py
@@ -19,26 +19,26 @@ class TestSitToStandModelBuilder:
     def test_build_returns_xml_string(self) -> None:
         xml_str = build_sit_to_stand_model()
         assert isinstance(xml_str, str)
-        assert "<?xml" in xml_str  # type: ignore
+        assert "<?xml" in xml_str
 
     def test_valid_sdf(self) -> None:
         xml_str = build_sit_to_stand_model()
         root = ET.fromstring(xml_str)
         assert root.tag == "sdf"
-        assert root.get("version") == "1.8"  # type: ignore
+        assert root.get("version") == "1.8"
 
     def test_model_name(self) -> None:
         xml_str = build_sit_to_stand_model()
         root = ET.fromstring(xml_str)
-        model = root.find("model")  # type: ignore
+        model = root.find("model")
         assert model is not None
-        assert model.get("name") == "sit_to_stand"  # type: ignore
+        assert model.get("name") == "sit_to_stand"
 
     def test_has_chair_body(self) -> None:
         """Model should contain a chair_seat link."""
         xml_str = build_sit_to_stand_model()
         root = ET.fromstring(xml_str)
-        links = {lnk.get("name") for lnk in root.findall(".//link")}  # type: ignore
+        links = {lnk.get("name") for lnk in root.findall(".//link")}
         assert "chair_seat" in links
 
     def test_chair_welded_to_world(self) -> None:
@@ -46,10 +46,12 @@ class TestSitToStandModelBuilder:
         xml_str = build_sit_to_stand_model()
         root = ET.fromstring(xml_str)
         for j in root.findall(".//joint"):
-            if j.get("name") == "chair_to_world":  # type: ignore
-                assert j.get("type") == "fixed"  # type: ignore
-                assert j.find("parent").text == "world"  # type: ignore
-                assert j.find("child").text == "chair_seat"  # type: ignore
+            if j.get("name") == "chair_to_world":
+                assert j.get("type") == "fixed"
+                parent = j.find("parent")
+                child = j.find("child")
+                assert parent is not None and parent.text == "world"
+                assert child is not None and child.text == "chair_seat"
                 break
         else:
             raise AssertionError("chair_to_world joint not found")
@@ -58,36 +60,38 @@ class TestSitToStandModelBuilder:
         """STS model should not have a barbell-to-body joint."""
         xml_str = build_sit_to_stand_model()
         root = ET.fromstring(xml_str)
-        joints = {j.get("name") for j in root.findall(".//joint")}  # type: ignore
+        joints = {j.get("name") for j in root.findall(".//joint")}
         assert not any("barbell_to" in (n or "") for n in joints)
 
     def test_has_initial_pose(self) -> None:
         xml_str = build_sit_to_stand_model()
         root = ET.fromstring(xml_str)
-        initial_pose = root.find(".//initial_pose")  # type: ignore
+        initial_pose = root.find(".//initial_pose")
         assert initial_pose is not None
-        assert initial_pose.get("name") == "seated"  # type: ignore
-        joints = initial_pose.findall("joint")  # type: ignore
+        assert initial_pose.get("name") == "seated"
+        joints = initial_pose.findall("joint")
         assert len(joints) > 0
 
     def test_initial_pose_seated_angles(self) -> None:
         """Seated position should have ~90 degrees hip and knee flexion."""
         xml_str = build_sit_to_stand_model()
         root = ET.fromstring(xml_str)
-        initial_pose = root.find(".//initial_pose")  # type: ignore
+        initial_pose = root.find(".//initial_pose")
         assert initial_pose is not None
         joint_values = {}
-        for j in initial_pose.findall("joint"):  # type: ignore
-            joint_values[j.get("name")] = float(j.text)  # type: ignore
+        for j in initial_pose.findall("joint"):
+            assert j.text is not None
+            joint_values[j.get("name")] = float(j.text)
         assert abs(joint_values["hip_l_flex"] - math.radians(90)) < 0.01
         assert abs(joint_values["knee_l"] - math.radians(-90)) < 0.01
 
     def test_has_gravity(self) -> None:
         xml_str = build_sit_to_stand_model()
         root = ET.fromstring(xml_str)
-        gravity = root.find(".//gravity")  # type: ignore
+        gravity = root.find(".//gravity")
         assert gravity is not None
-        assert "-9.806650" in gravity.text  # type: ignore
+        assert gravity.text is not None
+        assert "-9.806650" in gravity.text
 
     def test_custom_config(self) -> None:
         config = ExerciseConfig(
@@ -96,9 +100,9 @@ class TestSitToStandModelBuilder:
         builder = SitToStandModelBuilder(config)
         xml_str = builder.build()
         root = ET.fromstring(xml_str)
-        model = root.find(".//model")  # type: ignore
+        model = root.find(".//model")
         assert model is not None
-        assert model.get("name") == "sit_to_stand"  # type: ignore
+        assert model.get("name") == "sit_to_stand"
 
 
 class TestMakeChairSeatLink:
@@ -108,20 +112,20 @@ class TestMakeChairSeatLink:
         model = ET.Element("model")
         link = SitToStandModelBuilder._make_chair_seat_link(model)
         assert link.tag == "link"
-        assert link.get("name") == "chair_seat"  # type: ignore
+        assert link.get("name") == "chair_seat"
 
     def test_make_chair_seat_link_has_geometry(self) -> None:
         model = ET.Element("model")
         link = SitToStandModelBuilder._make_chair_seat_link(model)
-        assert link.find("visual") is not None  # type: ignore
-        assert link.find("collision") is not None  # type: ignore
+        assert link.find("visual") is not None
+        assert link.find("collision") is not None
 
     def test_add_chair_contact_attaches_collision(self) -> None:
         model = ET.Element("model")
         link = SitToStandModelBuilder._make_chair_seat_link(model)
-        initial_collisions = len(link.findall("collision"))  # type: ignore
+        initial_collisions = len(link.findall("collision"))
         SitToStandModelBuilder._add_chair_contact(link)
-        after_collisions = len(link.findall("collision"))  # type: ignore
+        after_collisions = len(link.findall("collision"))
         assert after_collisions == initial_collisions + 1
 
 

--- a/tests/unit/exercises/test_snatch.py
+++ b/tests/unit/exercises/test_snatch.py
@@ -21,56 +21,59 @@ class TestSnatchModelBuilder:
     def test_model_name(self) -> None:
         xml_str = build_snatch_model()
         root = ET.fromstring(xml_str)
-        model = root.find("model")  # type: ignore
+        model = root.find("model")
         assert model is not None
-        assert model.get("name") == "snatch"  # type: ignore
+        assert model.get("name") == "snatch"
 
     def test_barbell_attached_to_left_hand(self) -> None:
         xml_str = build_snatch_model()
         root = ET.fromstring(xml_str)
         for j in root.findall(".//joint"):
-            if j.get("name") == "barbell_to_left_hand":  # type: ignore
-                assert j.find("parent").text == "hand_l"  # type: ignore
-                assert j.find("child").text == "barbell_shaft"  # type: ignore
+            if j.get("name") == "barbell_to_left_hand":
+                parent = j.find("parent")
+                child = j.find("child")
+                assert parent is not None and parent.text == "hand_l"
+                assert child is not None and child.text == "barbell_shaft"
 
     def test_barbell_grip_joint_present(self) -> None:
         """barbell_to_left_hand joint must be present (single SDF-tree-safe grip)."""
         xml_str = build_snatch_model()
         root = ET.fromstring(xml_str)
-        joint_names = {j.get("name") for j in root.findall(".//joint")}  # type: ignore
-        assert "barbell_to_left_hand" in joint_names  # type: ignore
+        joint_names = {j.get("name") for j in root.findall(".//joint")}
+        assert "barbell_to_left_hand" in joint_names
 
     def test_attachment_is_fixed(self) -> None:
         xml_str = build_snatch_model()
         root = ET.fromstring(xml_str)
         for j in root.findall(".//joint"):
-            if j.get("name") == "barbell_to_left_hand":  # type: ignore
-                assert j.get("type") == "fixed"  # type: ignore
+            if j.get("name") == "barbell_to_left_hand":
+                assert j.get("type") == "fixed"
 
     def test_has_gravity(self) -> None:
         xml_str = build_snatch_model()
         root = ET.fromstring(xml_str)
-        gravity = root.find(".//gravity")  # type: ignore
+        gravity = root.find(".//gravity")
         assert gravity is not None
-        assert "-9.806650" in gravity.text  # type: ignore
+        assert gravity.text is not None
+        assert "-9.806650" in gravity.text
 
     def test_has_initial_pose(self) -> None:
         xml_str = build_snatch_model()
         root = ET.fromstring(xml_str)
-        initial_pose = root.find(".//initial_pose")  # type: ignore
+        initial_pose = root.find(".//initial_pose")
         assert initial_pose is not None
-        assert initial_pose.get("name") == "first_pull"  # type: ignore
-        joints = initial_pose.findall("joint")  # type: ignore
+        assert initial_pose.get("name") == "first_pull"
+        joints = initial_pose.findall("joint")
         assert len(joints) > 0, "initial_pose must contain at least one joint element"
 
     def test_default_plate_mass_40(self) -> None:
         xml_str = build_snatch_model()
         root = ET.fromstring(xml_str)
-        assert root.find(".//model") is not None  # type: ignore
+        assert root.find(".//model") is not None
 
     def test_custom_params(self) -> None:
         xml_str = build_snatch_model(body_mass=96, height=1.80, plate_mass_per_side=55)
         root = ET.fromstring(xml_str)
-        model = root.find(".//model")  # type: ignore
+        model = root.find(".//model")
         assert model is not None
-        assert model.get("name") == "snatch"  # type: ignore
+        assert model.get("name") == "snatch"

--- a/tests/unit/exercises/test_squat.py
+++ b/tests/unit/exercises/test_squat.py
@@ -19,41 +19,43 @@ class TestSquatModelBuilder:
     def test_build_returns_xml_string(self) -> None:
         xml_str = build_squat_model()
         assert isinstance(xml_str, str)
-        assert "<?xml" in xml_str  # type: ignore
+        assert "<?xml" in xml_str
 
     def test_valid_sdf(self) -> None:
         xml_str = build_squat_model()
         root = ET.fromstring(xml_str)
         assert root.tag == "sdf"
-        assert root.get("version") == "1.8"  # type: ignore
+        assert root.get("version") == "1.8"
 
     def test_model_name(self) -> None:
         xml_str = build_squat_model()
         root = ET.fromstring(xml_str)
-        model = root.find("model")  # type: ignore
+        model = root.find("model")
         assert model is not None
-        assert model.get("name") == "back_squat"  # type: ignore
+        assert model.get("name") == "back_squat"
 
     def test_has_barbell_to_torso_joint(self) -> None:
         xml_str = build_squat_model()
         root = ET.fromstring(xml_str)
-        joints = {j.get("name") for j in root.findall(".//joint")}  # type: ignore
-        assert "barbell_to_torso" in joints  # type: ignore
+        joints = {j.get("name") for j in root.findall(".//joint")}
+        assert "barbell_to_torso" in joints
 
     def test_barbell_to_torso_is_fixed(self) -> None:
         xml_str = build_squat_model()
         root = ET.fromstring(xml_str)
         for j in root.findall(".//joint"):
-            if j.get("name") == "barbell_to_torso":  # type: ignore
-                assert j.get("type") == "fixed"  # type: ignore
+            if j.get("name") == "barbell_to_torso":
+                assert j.get("type") == "fixed"
 
     def test_barbell_attached_to_torso(self) -> None:
         xml_str = build_squat_model()
         root = ET.fromstring(xml_str)
         for j in root.findall(".//joint"):
-            if j.get("name") == "barbell_to_torso":  # type: ignore
-                assert j.find("parent").text == "torso"  # type: ignore
-                assert j.find("child").text == "barbell_shaft"  # type: ignore
+            if j.get("name") == "barbell_to_torso":
+                parent = j.find("parent")
+                child = j.find("child")
+                assert parent is not None and parent.text == "torso"
+                assert child is not None and child.text == "barbell_shaft"
 
     def test_custom_config(self) -> None:
         config = ExerciseConfig(
@@ -63,32 +65,34 @@ class TestSquatModelBuilder:
         builder = SquatModelBuilder(config)
         xml_str = builder.build()
         root = ET.fromstring(xml_str)
-        model = root.find(".//model")  # type: ignore
+        model = root.find(".//model")
         assert model is not None
-        assert model.get("name") == "back_squat"  # type: ignore
+        assert model.get("name") == "back_squat"
 
     def test_has_gravity(self) -> None:
         xml_str = build_squat_model()
         root = ET.fromstring(xml_str)
-        gravity = root.find(".//gravity")  # type: ignore
+        gravity = root.find(".//gravity")
         assert gravity is not None
-        assert "-9.806650" in gravity.text  # type: ignore
+        assert gravity.text is not None
+        assert "-9.806650" in gravity.text
 
     def test_z_up_gravity(self) -> None:
         xml_str = build_squat_model()
         root = ET.fromstring(xml_str)
-        gravity = root.find(".//gravity")  # type: ignore
+        gravity = root.find(".//gravity")
         assert gravity is not None
-        parts = gravity.text.strip().split()  # type: ignore
+        assert gravity.text is not None
+        parts = gravity.text.strip().split()
         assert parts[0] == "0.000000"
         assert parts[1] == "0.000000"
-        assert "-9.806650" in parts[2]  # type: ignore
+        assert "-9.806650" in parts[2]
 
     def test_has_initial_pose(self) -> None:
         xml_str = build_squat_model()
         root = ET.fromstring(xml_str)
-        initial_pose = root.find(".//initial_pose")  # type: ignore
+        initial_pose = root.find(".//initial_pose")
         assert initial_pose is not None
-        assert initial_pose.get("name") == "unrack"  # type: ignore
-        joints = initial_pose.findall("joint")  # type: ignore
+        assert initial_pose.get("name") == "unrack"
+        joints = initial_pose.findall("joint")
         assert len(joints) > 0, "initial_pose must contain at least one joint element"

--- a/tests/unit/shared/test_body_model.py
+++ b/tests/unit/shared/test_body_model.py
@@ -82,9 +82,7 @@ class TestCreateFullBody:
     def test_pelvis_has_floating_joint(self, model: Any) -> None:
         create_full_body(model)
         floating_joints = [
-            j
-            for j in model.findall("joint")
-            if j.get("type") == "floating"
+            j for j in model.findall("joint") if j.get("type") == "floating"
         ]
         assert len(floating_joints) == 1
         assert floating_joints[0].get("name") == "ground_pelvis"
@@ -224,9 +222,7 @@ class TestCreateFullBody:
             name = link.get("name")
             if "virtual" in name:
                 continue  # virtual links have no geometry
-            assert link.find("collision") is not None, (
-                f"{name} missing collision"
-            )
+            assert link.find("collision") is not None, f"{name} missing collision"
 
     def test_total_mass_approximately_correct(self, model: Any) -> None:
         """Total mass of body links must equal spec.total_mass.

--- a/tests/unit/shared/test_body_model.py
+++ b/tests/unit/shared/test_body_model.py
@@ -22,12 +22,12 @@ from drake_models.shared.body.body_model import (
 class TestBodyModelSpec:
     def test_defaults(self) -> None:
         spec = BodyModelSpec()
-        assert spec.total_mass == 80.0  # type: ignore
+        assert spec.total_mass == 80.0
         assert spec.height == 1.75
 
     def test_custom_values(self) -> None:
         spec = BodyModelSpec(total_mass=100.0, height=1.90)
-        assert spec.total_mass == 100.0  # type: ignore
+        assert spec.total_mass == 100.0
         assert spec.height == 1.90
 
     def test_rejects_zero_mass(self) -> None:
@@ -49,7 +49,7 @@ class TestBodyModelSpec:
     def test_frozen(self) -> None:
         spec = BodyModelSpec()
         with pytest.raises(AttributeError):
-            spec.total_mass = 90.0  # type: ignore
+            spec.total_mass = 90.0
 
 
 class TestCreateFullBody:
@@ -60,21 +60,21 @@ class TestCreateFullBody:
     def test_returns_dict_of_links(self, model: Any) -> None:
         links = create_full_body(model)
         assert isinstance(links, dict)
-        assert "pelvis" in links  # type: ignore
-        assert "torso" in links  # type: ignore
-        assert "head" in links  # type: ignore
+        assert "pelvis" in links
+        assert "torso" in links
+        assert "head" in links
 
     def test_creates_minimum_links(self, model: Any) -> None:
         """15 body + 18 virtual links = 33 minimum."""
         create_full_body(model)
-        link_elements = model.findall("link")  # type: ignore
+        link_elements = model.findall("link")
         # 15 body + 2 lumbar virtual + 4 hip virtual + 4 shoulder virtual
         # + 2 ankle virtual + 2 wrist virtual = 29
         assert len(link_elements) >= 29
 
     def test_creates_joints(self, model: Any) -> None:
         create_full_body(model)
-        joints = model.findall("joint")  # type: ignore
+        joints = model.findall("joint")
         # 1 floating + 3 lumbar + 1 neck + 6 shoulder + 2 elbow + 4 wrist
         # + 6 hip + 2 knee + 4 ankle = 29 joints
         assert len(joints) >= 29
@@ -84,116 +84,116 @@ class TestCreateFullBody:
         floating_joints = [
             j
             for j in model.findall("joint")
-            if j.get("type") == "floating"  # type: ignore
+            if j.get("type") == "floating"
         ]
         assert len(floating_joints) == 1
-        assert floating_joints[0].get("name") == "ground_pelvis"  # type: ignore
+        assert floating_joints[0].get("name") == "ground_pelvis"
 
     def test_floating_joint_connects_world(self, model: Any) -> None:
         create_full_body(model)
         for j in model.findall("joint"):
-            if j.get("name") == "ground_pelvis":  # type: ignore
-                assert j.find("parent").text == "world"  # type: ignore
-                assert j.find("child").text == "pelvis"  # type: ignore
+            if j.get("name") == "ground_pelvis":
+                assert j.find("parent").text == "world"
+                assert j.find("child").text == "pelvis"
 
     def test_has_bilateral_limbs(self, model: Any) -> None:
         create_full_body(model)
-        link_names = {el.get("name") for el in model.findall("link")}  # type: ignore
+        link_names = {el.get("name") for el in model.findall("link")}
         for seg in ["upper_arm", "forearm", "hand", "thigh", "shank", "foot"]:
-            assert f"{seg}_l" in link_names, f"Missing {seg}_l"  # type: ignore
-            assert f"{seg}_r" in link_names, f"Missing {seg}_r"  # type: ignore
+            assert f"{seg}_l" in link_names, f"Missing {seg}_l"
+            assert f"{seg}_r" in link_names, f"Missing {seg}_r"
 
     def test_all_masses_positive(self, model: Any) -> None:
         create_full_body(model)
         for link in model.findall("link"):
-            mass = float(link.find("inertial/mass").text)  # type: ignore
-            assert mass > 0, f"{link.get('name')} mass={mass}"  # type: ignore
+            mass = float(link.find("inertial/mass").text)
+            assert mass > 0, f"{link.get('name')} mass={mass}"
 
     def test_default_spec_used(self, model: Any) -> None:
         links = create_full_body(model, spec=None)
-        assert "pelvis" in links  # type: ignore
+        assert "pelvis" in links
 
     def test_custom_spec(self, model: Any) -> None:
         spec = BodyModelSpec(total_mass=100.0, height=1.90)
         create_full_body(model, spec)
-        pelvis = model.find("link[@name='pelvis']")  # type: ignore
-        mass = float(pelvis.find("inertial/mass").text)  # type: ignore
+        pelvis = model.find("link[@name='pelvis']")
+        mass = float(pelvis.find("inertial/mass").text)
         assert mass == pytest.approx(100.0 * 0.142)
 
     def test_lumbar_compound_joint(self, model: Any) -> None:
         """Lumbar is now a 3-DOF compound: flex, lateral, rotate."""
         create_full_body(model)
-        joint_names = {j.get("name") for j in model.findall("joint")}  # type: ignore
-        assert "lumbar_flex" in joint_names  # type: ignore
-        assert "lumbar_lateral" in joint_names  # type: ignore
-        assert "lumbar_rotate" in joint_names  # type: ignore
+        joint_names = {j.get("name") for j in model.findall("joint")}
+        assert "lumbar_flex" in joint_names
+        assert "lumbar_lateral" in joint_names
+        assert "lumbar_rotate" in joint_names
 
         # Check chain: pelvis -> v1 -> v2 -> torso
         for j in model.findall("joint"):
-            if j.get("name") == "lumbar_flex":  # type: ignore
-                assert j.find("parent").text == "pelvis"  # type: ignore
-                assert j.find("child").text == "lumbar_virtual_1"  # type: ignore
-            elif j.get("name") == "lumbar_rotate":  # type: ignore
-                assert j.find("child").text == "torso"  # type: ignore
+            if j.get("name") == "lumbar_flex":
+                assert j.find("parent").text == "pelvis"
+                assert j.find("child").text == "lumbar_virtual_1"
+            elif j.get("name") == "lumbar_rotate":
+                assert j.find("child").text == "torso"
 
     def test_hip_compound_joints(self, model: Any) -> None:
         """Hip is now a 3-DOF compound: flex, adduct, rotate (bilateral)."""
         create_full_body(model)
-        joint_names = {j.get("name") for j in model.findall("joint")}  # type: ignore
+        joint_names = {j.get("name") for j in model.findall("joint")}
         for side in ("l", "r"):
-            assert f"hip_{side}_flex" in joint_names  # type: ignore
-            assert f"hip_{side}_adduct" in joint_names  # type: ignore
-            assert f"hip_{side}_rotate" in joint_names  # type: ignore
+            assert f"hip_{side}_flex" in joint_names
+            assert f"hip_{side}_adduct" in joint_names
+            assert f"hip_{side}_rotate" in joint_names
 
     def test_shoulder_compound_joints(self, model: Any) -> None:
         """Shoulder is now a 3-DOF compound: flex, adduct, rotate (bilateral)."""
         create_full_body(model)
-        joint_names = {j.get("name") for j in model.findall("joint")}  # type: ignore
+        joint_names = {j.get("name") for j in model.findall("joint")}
         for side in ("l", "r"):
-            assert f"shoulder_{side}_flex" in joint_names  # type: ignore
-            assert f"shoulder_{side}_adduct" in joint_names  # type: ignore
-            assert f"shoulder_{side}_rotate" in joint_names  # type: ignore
+            assert f"shoulder_{side}_flex" in joint_names
+            assert f"shoulder_{side}_adduct" in joint_names
+            assert f"shoulder_{side}_rotate" in joint_names
 
     def test_ankle_compound_joints(self, model: Any) -> None:
         """Ankle is now a 2-DOF compound: flex, invert (bilateral)."""
         create_full_body(model)
-        joint_names = {j.get("name") for j in model.findall("joint")}  # type: ignore
+        joint_names = {j.get("name") for j in model.findall("joint")}
         for side in ("l", "r"):
-            assert f"ankle_{side}_flex" in joint_names  # type: ignore
-            assert f"ankle_{side}_invert" in joint_names  # type: ignore
+            assert f"ankle_{side}_flex" in joint_names
+            assert f"ankle_{side}_invert" in joint_names
 
     def test_wrist_compound_joints(self, model: Any) -> None:
         """Wrist is now a 2-DOF compound: flex, deviate (bilateral)."""
         create_full_body(model)
-        joint_names = {j.get("name") for j in model.findall("joint")}  # type: ignore
+        joint_names = {j.get("name") for j in model.findall("joint")}
         for side in ("l", "r"):
-            assert f"wrist_{side}_flex" in joint_names  # type: ignore
-            assert f"wrist_{side}_deviate" in joint_names  # type: ignore
+            assert f"wrist_{side}_flex" in joint_names
+            assert f"wrist_{side}_deviate" in joint_names
 
     def test_virtual_links_present(self, model: Any) -> None:
         """Virtual links must exist for compound joint chains."""
         create_full_body(model)
-        link_names = {el.get("name") for el in model.findall("link")}  # type: ignore
-        assert "lumbar_virtual_1" in link_names  # type: ignore
-        assert "lumbar_virtual_2" in link_names  # type: ignore
+        link_names = {el.get("name") for el in model.findall("link")}
+        assert "lumbar_virtual_1" in link_names
+        assert "lumbar_virtual_2" in link_names
         for side in ("l", "r"):
-            assert f"hip_{side}_virtual_1" in link_names  # type: ignore
-            assert f"hip_{side}_virtual_2" in link_names  # type: ignore
-            assert f"shoulder_{side}_virtual_1" in link_names  # type: ignore
-            assert f"shoulder_{side}_virtual_2" in link_names  # type: ignore
-            assert f"ankle_{side}_virtual_1" in link_names  # type: ignore
-            assert f"wrist_{side}_virtual_1" in link_names  # type: ignore
+            assert f"hip_{side}_virtual_1" in link_names
+            assert f"hip_{side}_virtual_2" in link_names
+            assert f"shoulder_{side}_virtual_1" in link_names
+            assert f"shoulder_{side}_virtual_2" in link_names
+            assert f"ankle_{side}_virtual_1" in link_names
+            assert f"wrist_{side}_virtual_1" in link_names
 
     def test_neck_joint(self, model: Any) -> None:
         create_full_body(model)
         neck = None
         for j in model.findall("joint"):
-            if j.get("name") == "neck":  # type: ignore
+            if j.get("name") == "neck":
                 neck = j
                 break
         assert neck is not None
-        assert neck.find("parent").text == "torso"  # type: ignore
-        assert neck.find("child").text == "head"  # type: ignore
+        assert neck.find("parent").text == "torso"
+        assert neck.find("child").text == "head"
 
     def test_joint_axes_are_valid(self, model: Any) -> None:
         """Revolute joints use X (flex), Z (adduct/lateral), or Y (rotate) axes."""
@@ -204,27 +204,27 @@ class TestCreateFullBody:
         }
         create_full_body(model)
         for j in model.findall("joint"):
-            if j.get("type") == "revolute":  # type: ignore
-                xyz = j.find("axis/xyz").text.strip()  # type: ignore
-                assert xyz in valid_axes, (  # type: ignore
+            if j.get("type") == "revolute":
+                xyz = j.find("axis/xyz").text.strip()
+                assert xyz in valid_axes, (
                     f"Joint {j.get('name')} has unexpected axis: {xyz}"
                 )
 
     def test_links_have_visual_geometry(self, model: Any) -> None:
         create_full_body(model)
         for link in model.findall("link"):
-            name = link.get("name")  # type: ignore
-            if "virtual" in name:  # type: ignore
+            name = link.get("name")
+            if "virtual" in name:
                 continue  # virtual links have no geometry
-            assert link.find("visual") is not None, f"{name} missing visual"  # type: ignore
+            assert link.find("visual") is not None, f"{name} missing visual"
 
     def test_links_have_collision_geometry(self, model: Any) -> None:
         create_full_body(model)
         for link in model.findall("link"):
-            name = link.get("name")  # type: ignore
-            if "virtual" in name:  # type: ignore
+            name = link.get("name")
+            if "virtual" in name:
                 continue  # virtual links have no geometry
-            assert link.find("collision") is not None, (  # type: ignore
+            assert link.find("collision") is not None, (
                 f"{name} missing collision"
             )
 
@@ -253,14 +253,14 @@ class TestMakeCylinderSegmentLink:
             model, name="thigh_l", mass=8.0, length=0.42, radius=0.06
         )
         assert link.tag == "link"
-        assert link.get("name") == "thigh_l"  # type: ignore
+        assert link.get("name") == "thigh_l"
 
     def test_has_inertial_block(self) -> None:
         model = ET.Element("model")
         link = _make_cylinder_segment_link(
             model, name="shank_r", mass=3.76, length=0.43, radius=0.044
         )
-        inertial = link.find("inertial")  # type: ignore
+        inertial = link.find("inertial")
         assert inertial is not None
 
     def test_mass_center_at_minus_half_length(self) -> None:
@@ -269,9 +269,9 @@ class TestMakeCylinderSegmentLink:
         link = _make_cylinder_segment_link(
             model, name="thigh_l", mass=8.0, length=length, radius=0.06
         )
-        pose = link.find("inertial/pose")  # type: ignore
+        pose = link.find("inertial/pose")
         assert pose is not None
-        z_val = float(pose.text.split()[2])  # type: ignore
+        z_val = float(pose.text.split()[2])
         assert z_val == pytest.approx(-length / 2.0)
 
     def test_has_visual_geometry(self) -> None:
@@ -279,14 +279,14 @@ class TestMakeCylinderSegmentLink:
         link = _make_cylinder_segment_link(
             model, name="upper_arm_l", mass=2.24, length=0.33, radius=0.04
         )
-        assert link.find("visual") is not None  # type: ignore
+        assert link.find("visual") is not None
 
     def test_has_collision_geometry(self) -> None:
         model = ET.Element("model")
         link = _make_cylinder_segment_link(
             model, name="upper_arm_r", mass=2.24, length=0.33, radius=0.04
         )
-        assert link.find("collision") is not None  # type: ignore
+        assert link.find("collision") is not None
 
 
 class TestBuildStagedHelpers:
@@ -304,21 +304,21 @@ class TestBuildStagedHelpers:
 
         _t_mass, t_len, t_rad = _seg(spec, "torso")
         links = _build_shoulders(model, spec, t_len, t_rad)
-        assert "upper_arm_l" in links  # type: ignore
-        assert "upper_arm_r" in links  # type: ignore
+        assert "upper_arm_l" in links
+        assert "upper_arm_r" in links
 
     def test_build_elbows_creates_forearm_links(self, model_and_spec: Any) -> None:
         model, spec = model_and_spec
         # elbows need upper_arm links first for chain validation-free test
         links = _build_elbows(model, spec)
-        assert "forearm_l" in links  # type: ignore
-        assert "forearm_r" in links  # type: ignore
+        assert "forearm_l" in links
+        assert "forearm_r" in links
 
     def test_build_wrists_creates_hand_links(self, model_and_spec: Any) -> None:
         model, spec = model_and_spec
         links = _build_wrists(model, spec)
-        assert "hand_l" in links  # type: ignore
-        assert "hand_r" in links  # type: ignore
+        assert "hand_l" in links
+        assert "hand_r" in links
 
     def test_build_hips_creates_thigh_links(self, model_and_spec: Any) -> None:
         model, spec = model_and_spec
@@ -326,20 +326,20 @@ class TestBuildStagedHelpers:
 
         _p_mass, p_len, p_rad = _seg(spec, "pelvis")
         links = _build_hips(model, spec, p_len, p_rad)
-        assert "thigh_l" in links  # type: ignore
-        assert "thigh_r" in links  # type: ignore
+        assert "thigh_l" in links
+        assert "thigh_r" in links
 
     def test_build_knees_creates_shank_links(self, model_and_spec: Any) -> None:
         model, spec = model_and_spec
         links = _build_knees(model, spec)
-        assert "shank_l" in links  # type: ignore
-        assert "shank_r" in links  # type: ignore
+        assert "shank_l" in links
+        assert "shank_r" in links
 
     def test_build_ankles_creates_foot_links(self, model_and_spec: Any) -> None:
         model, spec = model_and_spec
         links = _build_ankles(model, spec)
-        assert "foot_l" in links  # type: ignore
-        assert "foot_r" in links  # type: ignore
+        assert "foot_l" in links
+        assert "foot_r" in links
 
     def test_build_lumbar_joints_creates_torso(self, model_and_spec: Any) -> None:
         model, spec = model_and_spec
@@ -347,9 +347,9 @@ class TestBuildStagedHelpers:
 
         _t_mass, t_len, _t_rad = _seg(spec, "torso")
         links = _build_lumbar_joints(model, spec, t_len)
-        assert "torso" in links  # type: ignore
-        assert "lumbar_virtual_1" in links  # type: ignore
-        assert "lumbar_virtual_2" in links  # type: ignore
+        assert "torso" in links
+        assert "lumbar_virtual_1" in links
+        assert "lumbar_virtual_2" in links
 
     def test_build_lumbar_joints_adds_three_joints(self, model_and_spec: Any) -> None:
         model, spec = model_and_spec
@@ -357,10 +357,10 @@ class TestBuildStagedHelpers:
 
         _t_mass, t_len, _t_rad = _seg(spec, "torso")
         _build_lumbar_joints(model, spec, t_len)
-        joint_names = {j.get("name") for j in model.findall("joint")}  # type: ignore
-        assert "lumbar_flex" in joint_names  # type: ignore
-        assert "lumbar_lateral" in joint_names  # type: ignore
-        assert "lumbar_rotate" in joint_names  # type: ignore
+        joint_names = {j.get("name") for j in model.findall("joint")}
+        assert "lumbar_flex" in joint_names
+        assert "lumbar_lateral" in joint_names
+        assert "lumbar_rotate" in joint_names
 
     def test_build_head_link_creates_head(self, model_and_spec: Any) -> None:
         model, spec = model_and_spec
@@ -369,7 +369,7 @@ class TestBuildStagedHelpers:
 
         _t_mass, t_len, _t_rad = _seg(spec, "torso")
         links = _build_head_link(model, spec, t_len)
-        assert "head" in links  # type: ignore
+        assert "head" in links
 
     def test_build_head_link_adds_neck_joint(self, model_and_spec: Any) -> None:
         model, spec = model_and_spec
@@ -377,5 +377,5 @@ class TestBuildStagedHelpers:
 
         _t_mass, t_len, _t_rad = _seg(spec, "torso")
         _build_head_link(model, spec, t_len)
-        joint_names = {j.get("name") for j in model.findall("joint")}  # type: ignore
-        assert "neck" in joint_names  # type: ignore
+        joint_names = {j.get("name") for j in model.findall("joint")}
+        assert "neck" in joint_names

--- a/tests/unit/shared/test_postconditions.py
+++ b/tests/unit/shared/test_postconditions.py
@@ -28,7 +28,7 @@ class TestEnsureValidXml:
 
     def test_accepts_xml_with_attributes(self) -> None:
         root = ensure_valid_xml('<link name="pelvis"/>')
-        assert root.get("name") == "pelvis"  # type: ignore
+        assert root.get("name") == "pelvis"
 
 
 class TestEnsurePositiveMass:

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -32,17 +32,17 @@ class TestBuildArgParser:
     def test_has_mass_default(self) -> None:
         parser = _build_arg_parser()
         args = parser.parse_args(["squat"])
-        assert args.mass == 80.0  # type: ignore
+        assert args.mass == 80.0
 
     def test_has_height_default(self) -> None:
         parser = _build_arg_parser()
         args = parser.parse_args(["squat"])
-        assert args.height == 1.75  # type: ignore
+        assert args.height == 1.75
 
     def test_has_plates_default(self) -> None:
         parser = _build_arg_parser()
         args = parser.parse_args(["squat"])
-        assert args.plates == 60.0  # type: ignore
+        assert args.plates == 60.0
 
     def test_verbose_flag(self) -> None:
         parser = _build_arg_parser()
@@ -123,21 +123,23 @@ class TestCLI:
         with patch("sys.stdout", new_callable=StringIO) as mock_stdout:
             main(["squat"])
         output = mock_stdout.getvalue()
-        root = ET.fromstring(output.strip())  # type: ignore
+        root = ET.fromstring(output.strip())
         assert root.tag == "sdf"
 
     def test_deadlift_to_stdout(self) -> None:
         with patch("sys.stdout", new_callable=StringIO) as mock_stdout:
             main(["deadlift"])
         output = mock_stdout.getvalue()
-        assert "<?xml" in output  # type: ignore
+        assert "<?xml" in output
 
     def test_custom_mass_and_height(self) -> None:
         with patch("sys.stdout", new_callable=StringIO) as mock_stdout:
             main(["bench_press", "--mass", "100", "--height", "1.90"])
         output = mock_stdout.getvalue()
-        root = ET.fromstring(output.strip())  # type: ignore
-        assert root.find(".//model").get("name") == "bench_press"  # type: ignore
+        root = ET.fromstring(output.strip())
+        model = root.find(".//model")
+        assert model is not None
+        assert model.get("name") == "bench_press"
 
     def test_output_to_file(self, tmp_path: object) -> None:
         import pathlib


### PR DESCRIPTION
Fix #185: Remove 237 type: ignore suppressions

Remove bare `# type: ignore` comments from 11 files by adding proper
null checks (assert element is not None) before accessing Element
attributes and text content. Mypy passes cleanly on all modified files.

**Files changed:**
- `src/drake_models/shared/body/body_segments.py`: 3 suppressions → null-safe assignments
- `tests/unit/exercises/test_bench_press.py`: 16 suppressions → assert helpers
- `tests/unit/exercises/test_clean_and_jerk.py`: 17 suppressions → assert helpers
- `tests/unit/exercises/test_deadlift.py`: 17 suppressions → assert helpers
- `tests/unit/exercises/test_gait.py`: 15 suppressions → assert helpers
- `tests/unit/exercises/test_sit_to_stand.py`: 25 suppressions → assert helpers
- `tests/unit/exercises/test_snatch.py`: 17 suppressions → assert helpers
- `tests/unit/exercises/test_squat.py`: 21 suppressions → assert helpers
- `tests/unit/shared/test_body_model.py`: 93 suppressions → assert helpers
- `tests/unit/shared/test_postconditions.py`: 1 suppression
- `tests/unit/test_cli.py`: 7 suppressions → assert helpers

Remaining suppressions are mostly `# type: ignore[attr-defined]` (Drake API) and `# type: ignore[index]` (numpy arrays with pydrake objects).

Closes #185