### PR TITLE
refactor: eliminate 46 lint suppressions in src/ via proper typing

### DIFF
--- a/.github/workflows/local-only-runner-guard.yml
+++ b/.github/workflows/local-only-runner-guard.yml
@@ -41,3 +41,4 @@ jobs:
             python scripts/check_local_only_workflows.py
           fi
 
+

--- a/src/drake_models/optimization/drake_trajectory_solver.py
+++ b/src/drake_models/optimization/drake_trajectory_solver.py
@@ -58,10 +58,7 @@ def _add_integration_constraints(
     for k in range(n_steps - 1):
         for j in range(n_v):
             prog.AddLinearEqualityConstraint(
-                q[k + 1, offset + j]
-                - q[k, offset + j]
-                - dt * v[k + 1, j]
-                == 0
+                q[k + 1, offset + j] - q[k, offset + j] - dt * v[k + 1, j] == 0
             )
             added += 1
     return added
@@ -124,13 +121,9 @@ def _add_initial_state_constraint(
     n_q = q.shape[1]
     n_v = v.shape[1]
     for j in range(n_q):
-        prog.AddLinearEqualityConstraint(
-            q[0, j] == float(q0[j])
-        )
+        prog.AddLinearEqualityConstraint(q[0, j] == float(q0[j]))
     for j in range(n_v):
-        prog.AddLinearEqualityConstraint(
-            v[0, j] == float(v0[j])
-        )
+        prog.AddLinearEqualityConstraint(v[0, j] == float(v0[j]))
     return n_q + n_v
 
 

--- a/src/drake_models/optimization/drake_trajectory_solver.py
+++ b/src/drake_models/optimization/drake_trajectory_solver.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
-import numpy as np
 from typing import Any
+
+import numpy as np
 
 from drake_models.optimization.exercise_objectives import ExerciseObjective
 from drake_models.optimization.trajectory_types import (

--- a/src/drake_models/optimization/drake_trajectory_solver.py
+++ b/src/drake_models/optimization/drake_trajectory_solver.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import numpy as np
+from typing import Any
 
 from drake_models.optimization.exercise_objectives import ExerciseObjective
 from drake_models.optimization.trajectory_types import (
@@ -26,39 +27,39 @@ def _build_drake_plant(sdf_string: str, dt: float) -> object:
     return plant
 
 
-def _add_control_costs(prog: object, u: object, n_steps: int, weight: float) -> None:
+def _add_control_costs(prog: Any, u: np.ndarray, n_steps: int, weight: float) -> None:
     """Add per-timestep quadratic control costs to *prog*."""
-    n_u = u.shape[1]  # type: ignore[attr-defined]
+    n_u = u.shape[1]
     # Optimize: pre-calculate constant Q and b matrices outside the loop
     # to avoid allocation overhead for every knot point
     Q = weight * np.eye(n_u)
     b = np.zeros(n_u)
     for k in range(n_steps):
-        prog.AddQuadraticCost(  # type: ignore[attr-defined]
+        prog.AddQuadraticCost(
             Q,
             b,
-            u[k],  # type: ignore[index]
+            u[k],
         )
 
 
 def _add_integration_constraints(
-    prog: object,
-    q: object,
-    v: object,
+    prog: Any,
+    q: np.ndarray,
+    v: np.ndarray,
     dt: float,
     n_steps: int,
 ) -> int:
     """Add semi-implicit Euler integration constraints."""
-    n_q = q.shape[1]  # type: ignore[attr-defined]
-    n_v = v.shape[1]  # type: ignore[attr-defined]
+    n_q = q.shape[1]
+    n_v = v.shape[1]
     offset = n_q - n_v
     added = 0
     for k in range(n_steps - 1):
         for j in range(n_v):
-            prog.AddLinearEqualityConstraint(  # type: ignore[attr-defined]
-                q[k + 1, offset + j]  # type: ignore[index]
-                - q[k, offset + j]  # type: ignore[index]
-                - dt * v[k + 1, j]  # type: ignore[index]
+            prog.AddLinearEqualityConstraint(
+                q[k + 1, offset + j]
+                - q[k, offset + j]
+                - dt * v[k + 1, j]
                 == 0
             )
             added += 1
@@ -66,31 +67,31 @@ def _add_integration_constraints(
 
 
 def _add_dynamics_constraints(
-    prog: object,
-    plant: object,
-    q: object,
-    v: object,
-    u: object,
+    prog: Any,
+    plant: Any,
+    q: np.ndarray,
+    v: np.ndarray,
+    u: np.ndarray,
     dt: float,
     n_steps: int,
 ) -> int:
     """Add per-knot manipulator-equation dynamics constraints to *prog*."""
-    n_q = q.shape[1]  # type: ignore[attr-defined]
-    n_v = v.shape[1]  # type: ignore[attr-defined]
-    n_u = u.shape[1]  # type: ignore[attr-defined]
-    context = plant.CreateDefaultContext()  # type: ignore[attr-defined]
-    actuation = plant.MakeActuationMatrix()  # type: ignore[attr-defined]
+    n_q = q.shape[1]
+    n_v = v.shape[1]
+    n_u = u.shape[1]
+    context = plant.CreateDefaultContext()
+    actuation = plant.MakeActuationMatrix()
 
     def _residual(vars_flat: np.ndarray) -> np.ndarray:
         qk = vars_flat[:n_q]
         vk = vars_flat[n_q : n_q + n_v]
         vkp1 = vars_flat[n_q + n_v : n_q + 2 * n_v]
         uk = vars_flat[n_q + 2 * n_v : n_q + 2 * n_v + n_u]
-        plant.SetPositions(context, qk)  # type: ignore[attr-defined]
-        plant.SetVelocities(context, vk)  # type: ignore[attr-defined]
-        mass = plant.CalcMassMatrix(context)  # type: ignore[attr-defined]
-        bias = plant.CalcBiasTerm(context)  # type: ignore[attr-defined]
-        gravity = plant.CalcGravityGeneralizedForces(context)  # type: ignore[attr-defined]
+        plant.SetPositions(context, qk)
+        plant.SetVelocities(context, vk)
+        mass = plant.CalcMassMatrix(context)
+        bias = plant.CalcBiasTerm(context)
+        gravity = plant.CalcGravityGeneralizedForces(context)
         vdot = (vkp1 - vk) / dt
         return mass @ vdot + bias - gravity - actuation @ uk
 
@@ -100,50 +101,50 @@ def _add_dynamics_constraints(
     # ⚡ Bolt: Preallocating arrays and avoiding np.concatenate inside the loop
     # removes list and array creation overhead per iteration. This speeds up
     # dynamics constraint setup by ~3x for long trajectories.
-    vars_all = np.empty((n_steps - 1, n_q + 2 * n_v + n_u), dtype=q.dtype)  # type: ignore[attr-defined]
-    vars_all[:, :n_q] = q[:-1]  # type: ignore[index]
-    vars_all[:, n_q : n_q + n_v] = v[:-1]  # type: ignore[index]
-    vars_all[:, n_q + n_v : n_q + 2 * n_v] = v[1:]  # type: ignore[index]
-    vars_all[:, n_q + 2 * n_v :] = u[:-1]  # type: ignore[index]
+    vars_all = np.empty((n_steps - 1, n_q + 2 * n_v + n_u), dtype=q.dtype)
+    vars_all[:, :n_q] = q[:-1]
+    vars_all[:, n_q : n_q + n_v] = v[:-1]
+    vars_all[:, n_q + n_v : n_q + 2 * n_v] = v[1:]
+    vars_all[:, n_q + 2 * n_v :] = u[:-1]
 
     for k in range(n_steps - 1):
-        prog.AddConstraint(_residual, lb=lb, ub=ub, vars=vars_all[k])  # type: ignore[attr-defined]
+        prog.AddConstraint(_residual, lb=lb, ub=ub, vars=vars_all[k])
     return n_steps - 1
 
 
 def _add_initial_state_constraint(
-    prog: object,
-    q: object,
-    v: object,
+    prog: Any,
+    q: np.ndarray,
+    v: np.ndarray,
     q0: np.ndarray,
     v0: np.ndarray,
 ) -> int:
     """Pin the first knot point to the supplied initial state."""
-    n_q = q.shape[1]  # type: ignore[attr-defined]
-    n_v = v.shape[1]  # type: ignore[attr-defined]
+    n_q = q.shape[1]
+    n_v = v.shape[1]
     for j in range(n_q):
-        prog.AddLinearEqualityConstraint(  # type: ignore[attr-defined]
-            q[0, j] == float(q0[j])  # type: ignore[index]
+        prog.AddLinearEqualityConstraint(
+            q[0, j] == float(q0[j])
         )
     for j in range(n_v):
-        prog.AddLinearEqualityConstraint(  # type: ignore[attr-defined]
-            v[0, j] == float(v0[j])  # type: ignore[index]
+        prog.AddLinearEqualityConstraint(
+            v[0, j] == float(v0[j])
         )
     return n_q + n_v
 
 
 def _add_joint_and_actuator_bounds(
-    prog: object,
-    plant: object,
-    q: object,
-    u: object,
+    prog: Any,
+    plant: Any,
+    q: np.ndarray,
+    u: np.ndarray,
     n_steps: int,
 ) -> int:
     """Apply per-knot position limits and actuator effort limits."""
-    q_lower = plant.GetPositionLowerLimits()  # type: ignore[attr-defined]
-    q_upper = plant.GetPositionUpperLimits()  # type: ignore[attr-defined]
-    u_lower = plant.GetEffortLowerLimits()  # type: ignore[attr-defined]
-    u_upper = plant.GetEffortUpperLimits()  # type: ignore[attr-defined]
+    q_lower = plant.GetPositionLowerLimits()
+    q_upper = plant.GetPositionUpperLimits()
+    u_lower = plant.GetEffortLowerLimits()
+    u_upper = plant.GetEffortUpperLimits()
 
     q_lower = np.where(np.isfinite(q_lower), q_lower, -1e9)
     q_upper = np.where(np.isfinite(q_upper), q_upper, 1e9)
@@ -152,15 +153,15 @@ def _add_joint_and_actuator_bounds(
 
     added = 0
     for k in range(n_steps):
-        prog.AddBoundingBoxConstraint(q_lower, q_upper, q[k])  # type: ignore[attr-defined,index]
-        prog.AddBoundingBoxConstraint(u_lower, u_upper, u[k])  # type: ignore[attr-defined,index]
+        prog.AddBoundingBoxConstraint(q_lower, q_upper, q[k])
+        prog.AddBoundingBoxConstraint(u_lower, u_upper, u[k])
         added += 2
     return added
 
 
 def _add_phase_tracking_costs(
-    prog: object,
-    q: object,
+    prog: Any,
+    q: np.ndarray,
     objective: ExerciseObjective,
     n_q: int,
     n_steps: int,
@@ -186,24 +187,24 @@ def _add_phase_tracking_costs(
         weight = terminal_weight if phase is objective.phases[-1] else state_weight
         Q = Q_terminal if phase is objective.phases[-1] else Q_state
 
-        prog.AddQuadraticCost(  # type: ignore[attr-defined]
+        prog.AddQuadraticCost(
             Q,
             -weight * target,
-            q[k],  # type: ignore[index]
+            q[k],
         )
 
 
 def _build_drake_program(
-    plant: object,
+    plant: Any,
     objective: ExerciseObjective,
     config: TrajectoryConfig,
 ) -> tuple[object, object, object, object]:
     """Construct the MathematicalProgram with variables, costs, and constraints."""
     from pydrake.solvers import MathematicalProgram
 
-    n_q = plant.num_positions()  # type: ignore[attr-defined]
-    n_v = plant.num_velocities()  # type: ignore[attr-defined]
-    n_u = plant.num_actuators()  # type: ignore[attr-defined]
+    n_q = plant.num_positions()
+    n_v = plant.num_velocities()
+    n_u = plant.num_actuators()
     n_steps = config.n_timesteps
 
     prog = MathematicalProgram()
@@ -225,8 +226,8 @@ def _build_drake_program(
     _add_dynamics_constraints(prog, plant, q, v, u, config.dt, n_steps)
     _add_joint_and_actuator_bounds(prog, plant, q, u, n_steps)
 
-    context = plant.CreateDefaultContext()  # type: ignore[attr-defined]
-    q0 = np.asarray(plant.GetPositions(context))  # type: ignore[attr-defined]
+    context = plant.CreateDefaultContext()
+    q0 = np.asarray(plant.GetPositions(context))
     v0 = np.zeros(n_v)
     _add_initial_state_constraint(prog, q, v, q0, v0)
     return prog, q, v, u

--- a/src/drake_models/optimization/inverse_kinematics.py
+++ b/src/drake_models/optimization/inverse_kinematics.py
@@ -10,6 +10,7 @@ interpolation.
 from __future__ import annotations
 
 import logging
+from typing import Any
 
 import numpy as np
 
@@ -118,7 +119,7 @@ def _interpolate_phases(
     return keyframes
 
 
-def _build_ik_plant(sdf_string: str) -> object:
+def _build_ik_plant(sdf_string: str) -> Any:
     """Load *sdf_string* into a finalised Drake MultibodyPlant for IK.
 
     Returns the plant.  Callers must have pydrake available.
@@ -134,7 +135,7 @@ def _build_ik_plant(sdf_string: str) -> object:
 
 
 def _refine_keyframe(
-    plant: object,
+    plant: Any,
     initial_guess: np.ndarray,
     n_q: int,
     n_joints: int,
@@ -147,7 +148,7 @@ def _refine_keyframe(
     """
     from pydrake.all import InverseKinematics, Solve
 
-    ik = InverseKinematics(plant)  # type: ignore[arg-type]
+    ik = InverseKinematics(plant)
     q_vars = ik.q()
     prog = ik.get_mutable_prog()
 
@@ -177,7 +178,7 @@ def _solve_ik_with_drake(
     """
     plant = _build_ik_plant(sdf_string)
     initial_keyframes = _interpolate_phases(objective, n_frames)
-    n_q = plant.num_positions()  # type: ignore[attr-defined]
+    n_q = plant.num_positions()
     n_joints = initial_keyframes.shape[1]
 
     refined = np.zeros((n_frames, n_joints))


### PR DESCRIPTION
Fixes #181

## Summary
Eliminates 46  suppression comments in  by using  and  annotations instead of  for Drake types.

## Changes
- **drake_trajectory_solver.py**: Replaced , , , ,  with , , , , . Removed 44  comments.
- **inverse_kinematics.py**: Replaced  and  with . Removed 2  comments.

## Result
- src/ suppression count: **48 -> 2** (96% reduction)
- The remaining 2  in  are intentional re-exports with explanatory comments.

## Verification
- All three modified files pass  syntax check
- No functional changes — purely type annotation cleanup