### PR TITLE
fix: enforce cyclomatic complexity (McCabe) in CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ target-version = "py310"
 select = [
     "E", "F", "I", "UP", "B", "T201", "SIM",
     "C4", "PIE", "PLE", "FURB", "RSE", "LOG",
-    "PERF", "RET",
+    "PERF", "RET", "C90",
 ]
 ignore = [
     "E501",
@@ -72,6 +72,9 @@ ignore = [
     "PERF203",
     "PERF401",
 ]
+
+[tool.ruff.lint.mccabe]
+max-complexity = 10
 
 [tool.ruff.lint.per-file-ignores]
 "scripts/**" = ["T201"]


### PR DESCRIPTION
Enables the C90 (McCabe) complexity check in Ruff with a threshold of 10 to ensure maintainable code quality across the fleet.