### PR TITLE
⚡ Bolt: O(1) dictionary lookups for performance loops

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -61,3 +61,6 @@
 ## 2026-05-01 - Drake MathematicalProgram Bounding Box Constraint Overhead
 **Learning:** When adding bounding box constraints to Drake's `MathematicalProgram` in loops over multiple time steps, iterating in Python over scalar variables causes significant expression and list allocation overhead. Drake's `AddBoundingBoxConstraint` correctly accepts flattened arrays (e.g., `q.flatten()`) along with tiled limits arrays (e.g., `np.tile(q_min, n_steps)`).
 **Action:** Always prefer flattening constraint variables and tiling bounds over iterating with Python loops when setting up `AddBoundingBoxConstraint`.
+## 2024-05-18 - Avoid O(N) linear scans and list.index() in nested loops
+**Learning:** Performing `list.index(name)` inside nested loops or iterating over a full array of names while checking `name in dictionary` causes unnecessary O(N) overhead per iteration. This is a common performance pattern when mapping between array indices and named joints/phases.
+**Action:** Always precompute a dictionary mapping names to indices (`name_to_idx = {name: i for i, name in enumerate(names)}`) outside the loop, or iterate over the dictionary items directly when populating fixed arrays, converting O(N) search to O(1) lookup.

--- a/src/drake_models/optimization/drake_trajectory_solver.py
+++ b/src/drake_models/optimization/drake_trajectory_solver.py
@@ -211,6 +211,8 @@ def _add_phase_tracking_costs(
 ) -> None:
     """Add phase-tracking quadratic costs to *prog*."""
     joint_names = objective.joint_names()
+    # ⚡ Bolt: Replace O(N) list.index() lookup in the inner loop with an O(1) dictionary lookup
+    joint_name_to_idx = {name: idx for idx, name in enumerate(joint_names)}
 
     # Optimize: pre-calculate constant Q matrices to avoid allocation overhead in loop
     Q_state = state_weight * np.eye(n_q)
@@ -220,8 +222,8 @@ def _add_phase_tracking_costs(
         k = int(phase.time_fraction * (n_steps - 1))
         target = np.zeros(n_q)
         for jname, angle in phase.joint_angles.items():
-            if jname in joint_names:
-                idx = joint_names.index(jname)
+            if jname in joint_name_to_idx:
+                idx = joint_name_to_idx[jname]
                 if idx < n_q:
                     target[idx] = angle
 

--- a/src/drake_models/optimization/objectives/__init__.py
+++ b/src/drake_models/optimization/objectives/__init__.py
@@ -119,10 +119,14 @@ class ExerciseObjective:
         Missing joints in a phase are filled with ``np.nan``.
         """
         names = self.joint_names()
+        # ⚡ Bolt: Replace O(N) linear scan over `names` in nested loop with O(1) dict lookup
+        # by iterating over the phase's joint_angles directly.
+        name_to_j = {name: j for j, name in enumerate(names)}
+
         n_phases = len(self.phases)
         arr = np.full((n_phases, len(names)), np.nan)
         for i, phase in enumerate(self.phases):
-            for j, name in enumerate(names):
-                if name in phase.joint_angles:
-                    arr[i, j] = phase.joint_angles[name]
+            for name, angle in phase.joint_angles.items():
+                if name in name_to_j:
+                    arr[i, name_to_j[name]] = angle
         return arr


### PR DESCRIPTION
💡 **What:** 
Replaced O(N) `list.index(jname)` lookups inside the inner loop of `_add_phase_tracking_costs()` with an O(1) dictionary lookup. Additionally, refactored `phase_angles_array()` to use a similar dictionary lookup rather than a nested loop iterating over all possible names.

🎯 **Why:** 
The application frequently iterates over phases and their joint target angles. Performing a linear search (`list.index()`) or iterating over a full array of names while doing `in` checks scales poorly with the number of variables/joints and phases. Converting these to dictionary lookups removes unnecessary O(N) overhead per iteration.

📊 **Impact:** 
Eliminates O(N^2) behavior in phase handling functions, providing a small but consistent speedup to trajectory optimization setup and interpolation loops, especially as models scale.

🔬 **Measurement:** 
Tested with `python3 -m pytest tests/` and verified that benchmarking tests ran and successfully built trajectories while passing correctness tests.

---
*PR created automatically by Jules for task [18073344456802866374](https://jules.google.com/task/18073344456802866374) started by @dieterolson*