### PR TITLE
fix: add .env.example with documented environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+# Environment configuration for Drake_Models
+# Copy to .env and fill in values
+
+# Drake installation path (optional, defaults to system Drake)
+# DRAKE_PATH=/opt/drake
+
+# Debug mode
+# DEBUG=false
+
+# Logging level (DEBUG, INFO, WARNING, ERROR)
+# LOG_LEVEL=INFO


### PR DESCRIPTION
Adds .env.example documenting all required environment variables with placeholder values.

## Changes
- Added .env.example with DRAKE_PATH, DEBUG, and LOG_LEVEL variables

Addresses P1 finding: Missing .env.example from the A-O comprehensive health assessment.