### PR TITLE
chore(testing): adopt fleet testing standards Phase 1 (#235)

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,11 +1,33 @@
 """Root conftest for pytest.
 
 Shared fixtures available to all tests in the suite.
+
+Fleet testing standards §5: thread-safety env vars are set BEFORE any
+heavy import to keep xdist workers stable and tests headless-safe.
+See Repository_Management/docs/FLEET_TESTING_STANDARDS.md.
 """
 
-import xml.etree.ElementTree as ET
+from __future__ import annotations
 
-import pytest
+import os
+
+# C-extension thread safety. Many "xdist worker crashed" failures
+# come from MKL/OpenBLAS forking under xdist. Pin to single-threaded
+# for tests; production code can re-thread itself if it needs to.
+os.environ.setdefault("OMP_NUM_THREADS", "1")
+os.environ.setdefault("OPENBLAS_NUM_THREADS", "1")
+os.environ.setdefault("MKL_NUM_THREADS", "1")
+os.environ.setdefault("NUMEXPR_NUM_THREADS", "1")
+
+# matplotlib headless backend, set before any matplotlib import.
+os.environ.setdefault("MPLBACKEND", "Agg")
+
+# Qt headless backend, for repos that import PyQt/PySide indirectly.
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import xml.etree.ElementTree as ET  # noqa: E402
+
+import pytest  # noqa: E402
 
 
 @pytest.fixture()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,13 +93,45 @@ pythonpath = [".", "src"]
 python_files = "test_*.py"
 python_classes = "Test*"
 python_functions = "test_*"
-addopts = "-ra -q --strict-markers --strict-config --durations=20"
+timeout = 60
+timeout_method = "thread"
+
+# Default lane: fast, deterministic, offline.
+# Heavy paths are deselected; nightly/release lanes opt in via -m overrides.
+addopts = """
+  -ra
+  -q
+  --strict-markers
+  --strict-config
+  --durations=20
+  -m "not slow and not live_simulation and not e2e and not requires_network"
+"""
+
 markers = [
-    "slow: marks tests as slow",
-    "integration: marks tests as integration tests",
-    "unit: marks tests as unit tests",
+    # ---- tier markers ----
+    "unit: pure logic, fully mocked, < 100 ms wall-clock",
+    "integration: cross-module / file-system / process boundaries, < 5 s",
+    "e2e: full-stack smoke tests; nightly + release gate only",
+    "slow: > 1 s wall-clock; deselect with -m 'not slow'",
+    "live_simulation: requires a real physics / math engine; deselect by default",
+
+    # ---- environment markers ----
+    "requires_network: needs real outbound network; deselect by default",
+    "requires_gpu: needs CUDA / Metal / ROCm",
+    "requires_gl: needs OpenGL or a display",
+    "headless_safe: verified under QT_QPA_PLATFORM=offscreen",
+
+    # ---- per-engine markers ----
     "requires_drake: tests requiring pydrake package",
-    "benchmark: marks performance benchmarks",
+    "requires_mujoco: skip when import mujoco fails",
+    "requires_pinocchio: skip when pinocchio is the stub PyPI wheel",
+    "requires_opensim: skip when import opensim fails",
+    "requires_matlab: skip when MATLAB Engine for Python is unavailable",
+
+    # ---- workflow markers ----
+    "serial: must run with -n 0 (xdist parallel breaks this test)",
+    "benchmark: marks performance benchmarks; not a primary correctness gate",
+    "smoke: release-blocking smoke; subset of e2e",
 ]
 filterwarnings = [
     "ignore::DeprecationWarning",


### PR DESCRIPTION
## Summary

Phase 1 of fleet testing alignment for Drake_Models per [FLEET_TESTING_STANDARDS.md](https://github.com/D-sorganization/Repository_Management/blob/main/docs/FLEET_TESTING_STANDARDS.md) (landed on Repository_Management main in PR #1139).

- **pyproject.toml**: additive §2 merge. Preserved existing markers (`slow`, `integration`, `unit`, `requires_drake`, `benchmark`); added `e2e`, `live_simulation`, `requires_network`, `requires_gpu`, `requires_gl`, `headless_safe`, `requires_mujoco`, `requires_pinocchio`, `requires_opensim`, `requires_matlab`, `serial`, `smoke`. Default lane now excludes `slow + live_simulation + e2e + requires_network`. Added `timeout = 60` (thread). `--strict-markers --strict-config` retained.
- **Coverage gate untouched**: existing `fail_under = 80` left as-is. Drake_Models is primarily a model-data repo; not raising or lowering the gate in Phase 1.
- **conftest.py (root)**: §5 thread-safety + headless env vars set BEFORE any heavy import.

`pytest --collect-only -q` exits clean.

Refs:
- EPIC: D-sorganization/Repository_Management#1140
- Issue: #235

## Test plan

- [x] `pytest --collect-only -q` passes (strict markers/config)
- [ ] CI green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)