### PR TITLE
feat: publish model_pack discovery surface for UpstreamDrift (#240)

### DIFF
--- a/.github/workflows/model-pack-smoke.yml
+++ b/.github/workflows/model-pack-smoke.yml
@@ -1,0 +1,63 @@
+name: Model Pack Smoke
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "model_pack.yaml"
+      - "src/drake_models/model_pack.py"
+      - "src/drake_models/__main__.py"
+      - "pyproject.toml"
+      - ".github/workflows/model-pack-smoke.yml"
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - "model_pack.yaml"
+      - "src/drake_models/model_pack.py"
+      - "src/drake_models/__main__.py"
+      - "pyproject.toml"
+      - ".github/workflows/model-pack-smoke.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  model-pack-api:
+    name: model_pack API smoke
+    runs-on: d-sorg-fleet
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+        env:
+          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+      - name: Install package
+        run: |
+          python -m venv .venv
+          . .venv/bin/activate
+          python -m pip install --upgrade pip
+          python -m pip install -e .
+
+      - name: Run model_pack API smoke
+        run: |
+          . .venv/bin/activate
+          python -c "from drake_models.model_pack import resolve, manifest, list_exercises; resolve(); manifest(); list_exercises()"
+
+      - name: Verify launcher CLI export contract
+        run: |
+          . .venv/bin/activate
+          python -m drake_models --exercise gait --export /tmp/gait.sdf
+          test -s /tmp/gait.sdf
+          grep -q '<sdf' /tmp/gait.sdf
+          grep -q 'version="1.8"' /tmp/gait.sdf

--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
 # Drake_Models
 
+## Used by UpstreamDrift
+
+This repository publishes a `model_pack.yaml` manifest and a
+`drake_models` console script that satisfy the UpstreamDrift fleet's shared
+launcher contract. See the umbrella tracker
+[D-sorganization/UpstreamDrift#5179](https://github.com/D-sorganization/UpstreamDrift/issues/5179)
+for the integration scope. The `biomech.model_pack` entry point exposes
+`resolve()`, `manifest()`, and `list_exercises()` for downstream discovery.
+
 Drake (pydrake) multibody models for five classical barbell exercises:
 
 - **Back Squat** -- barbell on upper trapezius, sagittal-plane hip/knee/ankle flexion

--- a/model_pack.yaml
+++ b/model_pack.yaml
@@ -1,0 +1,24 @@
+schema: model_pack/v1
+repo: Drake_Models
+package: drake_models
+engine: drake
+engine_version: ">=1.20"
+anthropometrics: winter_2009
+format: sdformat-1.8
+axis_convention: z_up
+models_root: src/drake_models/exercises
+exercises:
+  - id: squat
+    path: src/drake_models/exercises/squat
+  - id: deadlift
+    path: src/drake_models/exercises/deadlift
+  - id: bench_press
+    path: src/drake_models/exercises/bench_press
+  - id: snatch
+    path: src/drake_models/exercises/snatch
+  - id: clean_and_jerk
+    path: src/drake_models/exercises/clean_and_jerk
+  - id: gait
+    path: src/drake_models/exercises/gait
+  - id: sit_to_stand
+    path: src/drake_models/exercises/sit_to_stand

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "numpy>=1.26.4,<3.0.0",
     "matplotlib>=3.10.8",
     "defusedxml>=0.7.1",
+    "PyYAML>=6.0",
 ]
 
 [project.optional-dependencies]
@@ -49,12 +50,18 @@ Repository = "https://github.com/D-sorganization/Drake_Models"
 [project.scripts]
 drake-models = "drake_models.__main__:main"
 
+[project.entry-points."biomech.model_pack"]
+drake_models = "drake_models.model_pack"
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/drake_models"]
+
+[tool.hatch.build.targets.wheel.force-include]
+"model_pack.yaml" = "drake_models/model_pack.yaml"
 
 [tool.ruff]
 line-length = 88

--- a/src/drake_models/__main__.py
+++ b/src/drake_models/__main__.py
@@ -1,7 +1,13 @@
 """CLI entry point for Drake model generation.
 
-Usage:
-    python3 -m drake_models <exercise> [--mass MASS] [--height HEIGHT] [--plates PLATES]
+Two usage modes are supported:
+
+1. Legacy positional:
+   ``python3 -m drake_models <exercise> [--mass MASS] [--height HEIGHT] [--plates PLATES]``
+
+2. UpstreamDrift launcher contract:
+   ``python3 -m drake_models --exercise <name> --export <path>``
+   ``python3 -m drake_models --list-exercises``
 
 Exercises: squat, deadlift, bench_press, snatch, clean_and_jerk, gait, sit_to_stand
 """
@@ -11,6 +17,7 @@ from __future__ import annotations
 import argparse
 import logging
 import sys
+from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
@@ -39,8 +46,34 @@ def _add_exercise_argument(parser: argparse.ArgumentParser) -> None:
     """Add the positional ``exercise`` argument to *parser*."""
     parser.add_argument(
         "exercise",
+        nargs="?",
+        default=None,
         choices=sorted(EXERCISES.keys()),
-        help="Exercise to generate a model for.",
+        help="Exercise to generate a model for (positional form).",
+    )
+
+
+def _add_launcher_arguments(parser: argparse.ArgumentParser) -> None:
+    """Add UpstreamDrift launcher-style flag options to *parser*."""
+    parser.add_argument(
+        "--exercise",
+        dest="exercise_flag",
+        choices=sorted(EXERCISES.keys()),
+        default=None,
+        help="Exercise to generate a model for (flag form).",
+    )
+    parser.add_argument(
+        "--export",
+        dest="export",
+        type=str,
+        default=None,
+        help="Write the generated SDF to this path.",
+    )
+    parser.add_argument(
+        "--list-exercises",
+        dest="list_exercises",
+        action="store_true",
+        help="List declared exercise ids and exit.",
     )
 
 
@@ -90,6 +123,7 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         description="Generate Drake SDF models for barbell exercises.",
     )
     _add_exercise_argument(parser)
+    _add_launcher_arguments(parser)
     _add_anthropometric_arguments(parser)
     _add_output_arguments(parser)
     return parser
@@ -108,8 +142,7 @@ def _validate_args(parser: argparse.ArgumentParser, args: argparse.Namespace) ->
 def _write_output(xml_str: str, output_path: str | None) -> None:
     """Write *xml_str* to *output_path* or stdout when path is ``None``."""
     if output_path:
-        with open(output_path, "w") as f:
-            f.write(xml_str)
+        Path(output_path).write_text(xml_str, encoding="utf-8")
         logger.info("Wrote model to %s", output_path)
     else:
         stdout = sys.stdout
@@ -117,11 +150,45 @@ def _write_output(xml_str: str, output_path: str | None) -> None:
         stdout.write("\n")
 
 
-def main(argv: list[str] | None = None) -> None:
-    """Generate a Drake SDF model for a barbell exercise."""
+def _resolve_exercise(parser: argparse.ArgumentParser, args: argparse.Namespace) -> str:
+    """Resolve which exercise to build from positional and flag forms.
+
+    The flag form (``--exercise``) takes precedence; this lets the launcher
+    contract co-exist with the legacy positional CLI. ``parser.error`` is
+    called when neither form supplies an exercise.
+    """
+    chosen = args.exercise_flag or args.exercise
+    if chosen is None:
+        parser.error("an exercise is required (positional or via --exercise)")
+    return chosen
+
+
+def _handle_list_exercises() -> int:
+    """Print the declared exercise ids one per line and return exit code 0."""
+    from drake_models.model_pack import list_exercises
+
+    stdout = sys.stdout
+    for name in list_exercises():
+        stdout.write(name)
+        stdout.write("\n")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Generate a Drake SDF model for a barbell exercise.
+
+    Returns:
+        Process exit code. ``0`` on success; nonzero on argument errors
+        (raised via :class:`SystemExit` from ``argparse``).
+    """
     parser = _build_arg_parser()
     args = parser.parse_args(argv)
+
+    if args.list_exercises:
+        return _handle_list_exercises()
+
     _validate_args(parser, args)
+    exercise = _resolve_exercise(parser, args)
 
     logging.basicConfig(
         level=logging.DEBUG if args.verbose else logging.WARNING,
@@ -130,16 +197,18 @@ def main(argv: list[str] | None = None) -> None:
 
     import importlib
 
-    module = importlib.import_module(EXERCISES[args.exercise])
-    build_fn = getattr(module, BUILDER_FUNCTIONS[args.exercise])
+    module = importlib.import_module(EXERCISES[exercise])
+    build_fn = getattr(module, BUILDER_FUNCTIONS[exercise])
 
     xml_str: str = build_fn(
         body_mass=args.mass,
         height=args.height,
         plate_mass_per_side=args.plates,
     )
-    _write_output(xml_str, args.output)
+    output_path = args.export or args.output
+    _write_output(xml_str, output_path)
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/src/drake_models/model_pack.py
+++ b/src/drake_models/model_pack.py
@@ -1,0 +1,122 @@
+"""Model-pack entry point for UpstreamDrift launcher integration.
+
+Exposes the three functions required by the ``biomech.model_pack`` entry-point
+group:
+
+* :func:`resolve` -- locate the directory that holds the exercise sub-packages.
+* :func:`manifest` -- return the parsed ``model_pack.yaml`` manifest.
+* :func:`list_exercises` -- enumerate exercise ids declared in the manifest.
+
+The manifest itself (``model_pack.yaml``) ships at the repository root and is
+included in the wheel via ``[tool.hatch.build.targets.wheel.force-include]``
+so installed consumers can load it without the source tree.
+"""
+
+from __future__ import annotations
+
+from importlib import resources
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+_MANIFEST_FILENAME = "model_pack.yaml"
+
+
+def _load_manifest_text() -> str:
+    """Return the raw YAML text of the manifest, search wheel + source tree.
+
+    The wheel ships ``model_pack.yaml`` inside the ``drake_models`` package
+    via ``force-include``; the source tree keeps it at the repository root.
+    Try the package resource first, then fall back to walking up from this
+    file.
+    """
+    try:
+        pkg_files = resources.files("drake_models")
+        candidate = pkg_files.joinpath(_MANIFEST_FILENAME)
+        if candidate.is_file():
+            return candidate.read_text(encoding="utf-8")
+    except (FileNotFoundError, ModuleNotFoundError):
+        pass
+
+    here = Path(__file__).resolve()
+    for parent in here.parents:
+        candidate_path = parent / _MANIFEST_FILENAME
+        if candidate_path.is_file():
+            return candidate_path.read_text(encoding="utf-8")
+
+    raise FileNotFoundError(
+        f"Could not locate {_MANIFEST_FILENAME} in package resources or source tree",
+    )
+
+
+def manifest() -> dict[str, Any]:
+    """Return the parsed ``model_pack.yaml`` manifest as a ``dict``.
+
+    Returns:
+        Mapping with keys such as ``schema``, ``engine``, ``axis_convention``,
+        and ``exercises`` (a list of ``{"id": str, "path": str}`` entries).
+
+    Raises:
+        FileNotFoundError: When the manifest cannot be located.
+        yaml.YAMLError: When the manifest is not valid YAML.
+    """
+    data = yaml.safe_load(_load_manifest_text())
+    if not isinstance(data, dict):
+        raise ValueError(
+            f"{_MANIFEST_FILENAME} must parse to a mapping, got {type(data).__name__}",
+        )
+    return data
+
+
+def resolve() -> Path:
+    """Return the absolute path to the exercises root directory.
+
+    The path is taken from ``models_root`` in the manifest and resolved
+    relative to the directory containing ``model_pack.yaml``. The resulting
+    directory is guaranteed to exist (postcondition).
+
+    Returns:
+        Absolute :class:`~pathlib.Path` to the models root.
+
+    Raises:
+        FileNotFoundError: When neither the manifest nor the resolved root
+            exists on disk.
+    """
+    here = Path(__file__).resolve()
+    manifest_dir: Path | None = None
+    for parent in here.parents:
+        if (parent / _MANIFEST_FILENAME).is_file():
+            manifest_dir = parent
+            break
+
+    if manifest_dir is None:
+        # Installed wheel: manifest sits next to this module; exercises live
+        # in the package itself.
+        package_dir = here.parent
+        if (package_dir / _MANIFEST_FILENAME).is_file():
+            exercises_dir = package_dir / "exercises"
+            assert exercises_dir.is_dir(), (
+                f"resolved exercises dir does not exist: {exercises_dir}"
+            )
+            return exercises_dir
+        raise FileNotFoundError(
+            f"Could not locate {_MANIFEST_FILENAME} to resolve models root",
+        )
+
+    data = manifest()
+    models_root = data.get("models_root", "src/drake_models/exercises")
+    resolved = (manifest_dir / models_root).resolve()
+    assert resolved.is_dir(), f"resolved models root does not exist: {resolved}"
+    return resolved
+
+
+def list_exercises() -> list[str]:
+    """Return the ordered list of exercise ids declared in the manifest.
+
+    Returns:
+        A list of exercise id strings (e.g. ``["squat", "deadlift", ...]``).
+    """
+    data = manifest()
+    exercises = data.get("exercises", [])
+    return [str(entry["id"]) for entry in exercises]

--- a/tests/test_model_pack.py
+++ b/tests/test_model_pack.py
@@ -1,0 +1,219 @@
+"""Tests for the ``drake_models.model_pack`` UpstreamDrift integration.
+
+Mirrors the assertions used in the MuJoCo coordination issue so the two
+packages present an identical surface to the UpstreamDrift launcher.
+
+The ``pydrake`` parse test is marked ``live_simulation`` because it requires
+a working Drake install; the default pytest lane deselects that marker.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from drake_models.model_pack import list_exercises, manifest, resolve
+
+EXPECTED_EXERCISES = [
+    "squat",
+    "deadlift",
+    "bench_press",
+    "snatch",
+    "clean_and_jerk",
+    "gait",
+    "sit_to_stand",
+]
+
+
+class TestManifest:
+    """Tests for :func:`drake_models.model_pack.manifest`."""
+
+    def test_manifest_is_dict(self) -> None:
+        """``manifest()`` returns a mapping."""
+        data = manifest()
+        assert isinstance(data, dict)
+
+    def test_manifest_schema(self) -> None:
+        """Manifest declares the ``model_pack/v1`` schema."""
+        assert manifest()["schema"] == "model_pack/v1"
+
+    def test_manifest_engine(self) -> None:
+        """Engine must be ``drake``."""
+        assert manifest()["engine"] == "drake"
+
+    def test_manifest_engine_version(self) -> None:
+        """Engine version pin must require Drake 1.20 or newer."""
+        assert manifest()["engine_version"] == ">=1.20"
+
+    def test_manifest_format(self) -> None:
+        """Format must be ``sdformat-1.8``."""
+        assert manifest()["format"] == "sdformat-1.8"
+
+    def test_manifest_axis_convention(self) -> None:
+        """Axis convention must be ``z_up``."""
+        assert manifest()["axis_convention"] == "z_up"
+
+    def test_manifest_anthropometrics(self) -> None:
+        """Anthropometrics dataset must be ``winter_2009``."""
+        assert manifest()["anthropometrics"] == "winter_2009"
+
+    def test_manifest_package(self) -> None:
+        """Package name must be ``drake_models``."""
+        assert manifest()["package"] == "drake_models"
+
+
+class TestResolve:
+    """Tests for :func:`drake_models.model_pack.resolve`."""
+
+    def test_resolve_returns_path(self) -> None:
+        """``resolve()`` returns a :class:`Path`."""
+        assert isinstance(resolve(), Path)
+
+    def test_resolve_directory_exists(self) -> None:
+        """The resolved models root exists on disk."""
+        assert resolve().is_dir()
+
+    @pytest.mark.parametrize("exercise_id", EXPECTED_EXERCISES)
+    def test_resolve_contains_each_exercise_dir(self, exercise_id: str) -> None:
+        """Each declared exercise has a sub-directory under the models root."""
+        assert (resolve() / exercise_id).is_dir()
+
+
+class TestListExercises:
+    """Tests for :func:`drake_models.model_pack.list_exercises`."""
+
+    def test_list_exercises_returns_list_of_str(self) -> None:
+        """``list_exercises()`` returns a list of strings."""
+        ids = list_exercises()
+        assert isinstance(ids, list)
+        assert all(isinstance(name, str) for name in ids)
+
+    def test_list_exercises_count(self) -> None:
+        """Exactly seven exercises are declared."""
+        assert len(list_exercises()) == len(EXPECTED_EXERCISES)
+
+    def test_list_exercises_membership(self) -> None:
+        """The expected exercise ids are present."""
+        assert set(list_exercises()) == set(EXPECTED_EXERCISES)
+
+
+class TestEntryPoint:
+    """Tests verifying the ``biomech.model_pack`` entry-point registration."""
+
+    def test_entry_point_registered(self) -> None:
+        """``drake_models`` is discoverable in the ``biomech.model_pack`` group."""
+        from importlib.metadata import entry_points
+
+        eps = entry_points(group="biomech.model_pack")
+        names = {ep.name for ep in eps}
+        if "drake_models" not in names:
+            pytest.skip(
+                "package not installed in editable mode; entry point unavailable",
+            )
+        ep = next(ep for ep in eps if ep.name == "drake_models")
+        loaded = ep.load()
+        assert hasattr(loaded, "resolve")
+        assert hasattr(loaded, "manifest")
+        assert hasattr(loaded, "list_exercises")
+
+
+class TestLauncherCli:
+    """Tests for the ``drake-models`` launcher CLI contract."""
+
+    @pytest.mark.parametrize("exercise_id", EXPECTED_EXERCISES)
+    def test_export_writes_sdf_file_and_exits_zero(
+        self,
+        exercise_id: str,
+        tmp_path: Path,
+    ) -> None:
+        """``--exercise X --export PATH`` exits 0 and writes SDF 1.8 (Z-up)."""
+        out = tmp_path / f"{exercise_id}.sdf"
+        result = subprocess.run(  # noqa: S603 - controlled args
+            [
+                sys.executable,
+                "-m",
+                "drake_models",
+                "--exercise",
+                exercise_id,
+                "--export",
+                str(out),
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, result.stderr
+        assert out.is_file()
+        text = out.read_text(encoding="utf-8")
+        assert "<sdf" in text
+        assert 'version="1.8"' in text
+
+    def test_list_exercises_cli(self) -> None:
+        """``--list-exercises`` exits 0 and prints every exercise id."""
+        result = subprocess.run(  # noqa: S603 - controlled args
+            [sys.executable, "-m", "drake_models", "--list-exercises"],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, result.stderr
+        printed = set(result.stdout.split())
+        assert set(EXPECTED_EXERCISES).issubset(printed)
+
+
+@pytest.mark.live_simulation
+@pytest.mark.requires_drake
+class TestPydrakeParse:
+    """Verify each exported SDF parses through ``pydrake.multibody.parsing``.
+
+    Marked ``live_simulation`` (deselected by the default pytest lane); only
+    runs when Drake is installed via the ``[drake]`` extra.
+    """
+
+    @pytest.mark.parametrize("exercise_id", EXPECTED_EXERCISES)
+    def test_sdf_parses_via_pydrake(
+        self,
+        exercise_id: str,
+        tmp_path: Path,
+    ) -> None:
+        """Each exported SDF file loads via :class:`pydrake...Parser`."""
+        from pydrake.multibody.parsing import Parser  # type: ignore[import]
+        from pydrake.multibody.plant import MultibodyPlant  # type: ignore[import]
+
+        out = tmp_path / f"{exercise_id}.sdf"
+        result = subprocess.run(  # noqa: S603 - controlled args
+            [
+                sys.executable,
+                "-m",
+                "drake_models",
+                "--exercise",
+                exercise_id,
+                "--export",
+                str(out),
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, result.stderr
+
+        plant = MultibodyPlant(time_step=0.0)
+        parser = Parser(plant)
+        _add_models(parser, out)
+        plant.Finalize()
+        assert plant.num_bodies() > 1
+
+
+def _add_models(parser: Any, sdf_file: Path) -> None:
+    """Load *sdf_file* across Drake parser API versions."""
+    if hasattr(parser, "AddModels"):
+        parser.AddModels(str(sdf_file))
+        return
+    if hasattr(parser, "AddModelFromFile"):
+        parser.AddModelFromFile(str(sdf_file))
+        return
+    parser.AddModelsFromUrl(sdf_file.as_uri())

--- a/tests/test_pydrake_api_contract.py
+++ b/tests/test_pydrake_api_contract.py
@@ -1,0 +1,84 @@
+"""Guard tests for Drake-specific API usage patterns.
+
+Two sharp edges in ``pydrake`` (documented in the UpstreamDrift CLAUDE.md)
+must be respected by any code in this repository that touches Drake:
+
+1. **Explicit imports only.** Attribute access on the ``pydrake`` namespace
+   does not work -- callers must use ``from pydrake.X import Y``.
+2. **``body.body_frame()`` direct access.** Wrapping a body in a
+   ``FixedOffsetFrame`` to retrieve its frame is incorrect; the body's own
+   ``body_frame()`` accessor is the supported API.
+
+These tests encode each rule as a guard so a regression that re-introduces
+the bad pattern fails *here* rather than later in UpstreamDrift.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+SRC_ROOT = Path(__file__).resolve().parent.parent / "src" / "drake_models"
+
+# Match ``from pydrake import ...`` (and ``import pydrake`` without submodule).
+# Allowed:   ``from pydrake.X import Y`` / ``from pydrake.X.Y import Z``.
+# Disallowed: ``from pydrake import X`` / ``import pydrake`` as bare module.
+_BAD_IMPORT_PATTERNS = (
+    re.compile(r"^\s*from\s+pydrake\s+import\s+", re.MULTILINE),
+    re.compile(r"^\s*import\s+pydrake\s*$", re.MULTILINE),
+    re.compile(r"^\s*import\s+pydrake\s+as\s+", re.MULTILINE),
+)
+
+# Match construction of ``FixedOffsetFrame(... body_frame ...)`` -- the
+# disallowed pattern when used to get a body's frame. Any reference to
+# ``FixedOffsetFrame`` in source under ``src/drake_models`` is flagged.
+_BAD_FRAME_PATTERN = re.compile(r"\bFixedOffsetFrame\s*\(")
+
+
+def _iter_python_sources() -> list[Path]:
+    """Return every ``.py`` file under ``src/drake_models``."""
+    return sorted(SRC_ROOT.rglob("*.py"))
+
+
+def _read(path: Path) -> str:
+    """Read source file text (utf-8); empty string on read failure."""
+    try:
+        return path.read_text(encoding="utf-8")
+    except OSError:
+        return ""
+
+
+class TestExplicitPydrakeImports:
+    """Source must never import the bare ``pydrake`` namespace."""
+
+    @pytest.mark.parametrize(
+        "source_path", _iter_python_sources(), ids=lambda p: p.name
+    )
+    def test_no_bare_pydrake_import(self, source_path: Path) -> None:
+        """Each source file uses explicit ``from pydrake.X import Y`` imports."""
+        text = _read(source_path)
+        for pattern in _BAD_IMPORT_PATTERNS:
+            matches = pattern.findall(text)
+            assert not matches, (
+                f"{source_path.relative_to(SRC_ROOT)}: matched disallowed import "
+                f"pattern {pattern.pattern!r}. Use explicit "
+                f"'from pydrake.<submodule> import <Name>' instead."
+            )
+
+
+class TestBodyFrameDirectAccess:
+    """Source must use ``body.body_frame()`` rather than ``FixedOffsetFrame``."""
+
+    @pytest.mark.parametrize(
+        "source_path", _iter_python_sources(), ids=lambda p: p.name
+    )
+    def test_no_fixed_offset_frame_construction(self, source_path: Path) -> None:
+        """``FixedOffsetFrame(...)`` must not appear in ``src/drake_models``."""
+        text = _read(source_path)
+        matches = _BAD_FRAME_PATTERN.findall(text)
+        assert not matches, (
+            f"{source_path.relative_to(SRC_ROOT)}: constructs FixedOffsetFrame. "
+            "Use ``body.body_frame()`` directly instead."
+        )


### PR DESCRIPTION
## Summary

Implements the Drake_Models side of the UpstreamDrift biomechanics-fleet integration ([UpstreamDrift#5179](https://github.com/D-sorganization/UpstreamDrift/issues/5179)). Publishes the stable launcher-discovery surface UpstreamDrift uses to find and host this repo's exercise content.

- `model_pack.yaml` (schema `model_pack/v1`) at repo root; force-included in the wheel via hatch so `resolve()` works in both source and installed layouts. Declares `engine=drake`, `format=sdformat-1.8`, `axis_convention=z_up`.
- `drake_models.model_pack`: `resolve()`, `manifest()`, `list_exercises()`.
- `[project.entry-points."biomech.model_pack"]` registered in `pyproject.toml`.
- CLI gains `--exercise` / `--export` / `--list-exercises` to match the launcher contract; legacy positional `exercise` is preserved for backwards compatibility.
- Dedicated `model-pack-smoke` workflow imports the discovery surface and runs the CLI export path on every PR touching the contract.
- Adds `test_pydrake_api_contract.py` — guard tests for the two pydrake API rules called out in the fleet CLAUDE.md (explicit `from pydrake.X import Y` imports, `body.body_frame()` over `FixedOffsetFrame`), so the launcher integration cannot regress them.

Closes #240.

## Test plan

- [x] `pytest tests/test_model_pack.py tests/test_pydrake_api_contract.py` — 139 tests pass.
- [x] `ruff check` — clean.
- [x] `ruff format --check` — clean.
- [x] `mypy src` — no issues on 55 sources.
- [ ] CI Standard suite stays green.
- [ ] New Model Pack Smoke workflow turns green.
- [ ] `live_simulation` + `requires_drake` `TestPydrakeParse` runs in environments with Drake installed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)