### PR TITLE
ci: workflow protection — timeouts + preventive lint

### DIFF
--- a/.github/workflows/Verify-Issue-Closure.yml
+++ b/.github/workflows/Verify-Issue-Closure.yml
@@ -21,6 +21,7 @@ permissions:
 
 jobs:
   verify-closure:
+    timeout-minutes: 30
     # Skip if the issue was just reopened (state_reason == 'reopened') so we
     # don't loop on our own reopen action. Also skip if the closer is the
     # github-actions bot itself (defence in depth).

--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -128,6 +128,7 @@ jobs:
             -v
 
   local-only-workflows:
+    timeout-minutes: 30
     name: Reject hosted runner routing
     runs-on: d-sorg-fleet
     steps:

--- a/.github/workflows/lint-workflow-files.yml
+++ b/.github/workflows/lint-workflow-files.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: d-sorg-fleet
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/lint-workflow-files.yml
+++ b/.github/workflows/lint-workflow-files.yml
@@ -1,0 +1,65 @@
+name: Lint Workflow Files
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: lint-workflow-files-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Identify modified workflow files
+        id: changed
+        run: |
+          set -eo pipefail
+          CHANGED=$(git diff --name-only HEAD~1 HEAD -- '.github/workflows/*.yml' '.github/workflows/*.yaml' | grep -v 'lint-workflow-files.yml' || true)
+          if [ -z "$CHANGED" ]; then
+            echo "No workflow files changed."
+            exit 0
+          fi
+          echo "files<<EOF" >> $GITHUB_OUTPUT
+          echo "$CHANGED" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Require timeout-minutes, concurrency, cancel-in-progress
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          FILES: ${{ steps.changed.outputs.files }}
+        run: |
+          set -eo pipefail
+          [ -z "$FILES" ] && exit 0
+          FAIL=""
+          while IFS= read -r f; do
+            [ -z "$f" ] && continue
+            [ ! -f "$f" ] && continue
+            if ! grep -q '^\s*timeout-minutes:' "$f"; then
+              FAIL="${FAIL}\n  - $f: missing timeout-minutes"
+            fi
+            if ! grep -q '^concurrency:' "$f"; then
+              FAIL="${FAIL}\n  - $f: missing concurrency block"
+            fi
+            if grep -q '^concurrency:' "$f" && ! grep -q 'cancel-in-progress:\s*true' "$f"; then
+              FAIL="${FAIL}\n  - $f: cancel-in-progress not set to true"
+            fi
+          done <<< "$FILES"
+          if [ -n "$FAIL" ]; then
+            printf "::error::Workflow lint failed:%b\n" "$FAIL"
+            COMMENT=$(printf "## Workflow lint failed\n\nThe following modified workflow files are missing required protections:%b\n\n### Required keys\n- \`timeout-minutes:\` at job level (e.g. 30 for tests, 60 for builds)\n- \`concurrency:\` block at workflow level\n- \`cancel-in-progress: true\` inside concurrency\n\n### Why\nThese protections prevent the queue-saturation pattern that clogged the fleet on 2026-05-15/16. See CLAUDE.md for the canonical YAML pattern." "$FAIL")
+            gh pr comment "${{ github.event.pull_request.number }}" --repo "${{ github.repository }}" --body "$COMMENT" >/dev/null
+            exit 1
+          fi
+          echo "::notice::All modified workflow files pass lint."

--- a/.github/workflows/local-only-runner-guard.yml
+++ b/.github/workflows/local-only-runner-guard.yml
@@ -11,6 +11,7 @@ permissions:
 
 jobs:
   local-only-workflows:
+    timeout-minutes: 30
     name: Reject hosted runner routing
     runs-on: d-sorg-fleet
     steps:


### PR DESCRIPTION
## Workflow protection — timeouts + preventive lint

Adds `timeout-minutes` to all workflow jobs missing them (default 30 tests/lint, 60 builds, 90 perf/bench, 120 long-run) and installs `.github/workflows/lint-workflow-files.yml` which blocks future PRs that add workflows without:

- `timeout-minutes:` at job level
- `concurrency:` block at workflow level
- `cancel-in-progress: true` inside concurrency

### Why
Queue-saturation pattern on 2026-05-15/16 clogged the fleet. Preventive lint stops the regression from coming back.

Companion to Tools / UpstreamDrift / Gasification_Model PRs (those also add `paths:` filters; this PR is timeouts + lint only).