### PR TITLE
fix(ci): add timeout-minutes:5 to pip-audit step (hang protection)

### DIFF
--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -72,6 +72,7 @@ jobs:
           fi
 
       - name: Security Audit
+        timeout-minutes: 5
         run: |
           python -m venv .audit-venv
           . .audit-venv/bin/activate


### PR DESCRIPTION
pip-audit hangs indefinitely on overloaded runners with no step-level timeout, eventually getting OOM-killed and showing as cancelled (not failed). This poisons CI status across the fleet. Adding timeout-minutes:5 kills the step cleanly with a proper failure. Already fixed on main in OpenSim_Models, Pinocchio_Models, MuJoCo_Models.