### PR TITLE
fix(workflows): repair pre-existing broken workflow YAMLs

### DIFF
--- a/.github/workflows/anti-phantom-merge.yml
+++ b/.github/workflows/anti-phantom-merge.yml
@@ -34,7 +34,7 @@ jobs:
         run: |
           set -eo pipefail
 
-          # Override label takes precedence — admins only
+          # Override label takes precedence -- admins only
           LABELS=$(gh pr view "$PR" --repo "$REPO" --json labels --jq '[.labels[].name] | join(",")')
           if echo "$LABELS" | grep -qw "phantom-guard-override"; then
             ACTOR="${{ github.actor }}"

--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -46,7 +46,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           cache: 'pip'
-        with: { python-version: "3.11" }
+          python-version: "3.11"
         env:
           FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
       - run: pip install -e .


### PR DESCRIPTION
Repairs workflow files that had duplicate keys and encoding issues causing parse failures. Follows same fix pattern as UpstreamDrift PR #5669. Unblocks CI for this repo.

## Fixes
- ci-standard.yml: merged duplicate `with:` keys on setup-python step
- anti-phantom-merge.yml: re-encoded cp1252 to utf-8 (em-dash byte 0x97)