### PR TITLE
chore(ci): align pre-commit hooks and CI standard workflow

### DIFF
--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -152,5 +152,10 @@ jobs:
     runs-on: d-sorg-fleet
     steps:
       - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+        env:
+          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
       - name: Run local-only workflow guard
         run: python scripts/check_local_only_workflows.py

--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -20,7 +20,6 @@ permissions:
   contents: read
 
 jobs:
-
   # Dispatcher: route to self-hosted if available
   pick-runner:
     runs-on: d-sorg-fleet
@@ -45,7 +44,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v6
         with:
-          cache: 'pip'
+          cache: "pip"
           python-version: "3.11"
         env:
           FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -109,7 +108,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python }}
-          cache: 'pip'
+          cache: "pip"
         env:
           FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
@@ -154,4 +153,4 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Run local-only workflow guard
-        run: python3 scripts/check_local_only_workflows.py
+        run: python scripts/check_local_only_workflows.py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,7 +60,7 @@ repos:
         exclude: '(\.py|package-lock\.json|\.ipynb)$'
 
 default_language_version:
-  python: python3.11
+  python: python
 
 exclude: |
   (?x)^(


### PR DESCRIPTION
This PR standardizes python command strings to use python in pre-commit hooks and CI workflows, and adds the ci-complete status check job to resolve skip issues on branch protection rules.