### PR TITLE
⚡ Bolt: [performance improvement] Optimize integration constraint matrix allocation

### DIFF
--- a/src/drake_models/optimization/drake_trajectory_solver.py
+++ b/src/drake_models/optimization/drake_trajectory_solver.py
@@ -65,7 +65,10 @@ def _add_integration_constraints(
 
     # Optimize: Preallocate the constraints matrix and variable array
     # to avoid allocation overhead for each step and degree of freedom.
-    A = np.hstack((np.eye(n_v), -np.eye(n_v), -dt * np.eye(n_v)))
+    A = np.zeros((n_v, 3 * n_v))
+    np.fill_diagonal(A[:, :n_v], 1.0)
+    np.fill_diagonal(A[:, n_v : 2 * n_v], -1.0)
+    np.fill_diagonal(A[:, 2 * n_v :], -dt)
     b = np.zeros(n_v)
 
     # ⚡ Bolt: Preallocating arrays and combining variables for matrix operations


### PR DESCRIPTION
💡 What: Optimized the matrix building in `_add_integration_constraints` by avoiding `np.hstack` and intermediate `np.eye` allocations, in favor of allocating the matrix once with `np.zeros` and using `np.fill_diagonal`.

🎯 Why: During benchmark setup, calling `np.hstack` over multiple newly-allocated identity matrices creates unnecessary temporary python tuples and numpy arrays, increasing allocation overhead inside optimization formulation routines. 

📊 Impact: Minor reduction in matrix setup time in hot paths. Mean execution time of `test_bench_add_integration_constraints` drops measurably, proving reduced allocation overhead.

🔬 Measurement: Run the specific benchmark using `python3 -m pytest tests/benchmarks/test_trajectory_benchmarks.py -k test_bench_add_integration_constraints -v --benchmark-only` to verify the execution time and OPS improvement.

---
*PR created automatically by Jules for task [18302381654405685942](https://jules.google.com/task/18302381654405685942) started by @dieterolson*